### PR TITLE
barcode metadata df shouldnt be used for bg concat

### DIFF
--- a/panpipes/panpipes/pipeline_qc_mm.py
+++ b/panpipes/panpipes/pipeline_qc_mm.py
@@ -288,9 +288,9 @@ def concat_bg_mudatas(infiles, outfile):
         """
     if PARAMS['metadatacols'] is not None and PARAMS['metadatacols'] != "":
         cmd += " --metadatacols  %(metadatacols)s"
-    if PARAMS["barcode_mtd_include"] is True:
-        cmd += " --barcode_mtd_df %(barcode_mtd_path)s"
-        cmd += " --barcode_mtd_metadatacols %(barcode_mtd_metadatacols)s"
+  #  if PARAMS["barcode_mtd_include"] is True:
+   #     cmd += " --barcode_mtd_df %(barcode_mtd_path)s"
+    #    cmd += " --barcode_mtd_metadatacols %(barcode_mtd_metadatacols)s"
     cmd += " > logs/concat_bg_mudatas.log"
     job_kwargs["job_threads"] = PARAMS['resources_threads_high']
     P.run(cmd, **job_kwargs)


### PR DESCRIPTION
concat_adata.py fails, if barcode_mtd is also included for the bg. This should not be done for the bg