### PR TITLE
[QC_MM] Multiple different ADT libraries

### DIFF
--- a/panpipes/funcs/processing.py
+++ b/panpipes/funcs/processing.py
@@ -384,4 +384,3 @@ def mu_get_obs(mdata, features=[],modalities=[], layers=None):
     df = concat(out, axis=1)
     df.columns = ['-'.join(col).strip() for col in df.columns.values]
     return df
-

--- a/panpipes/panpipes/pipeline_qc_mm.py
+++ b/panpipes/panpipes/pipeline_qc_mm.py
@@ -124,10 +124,6 @@ def load_mudatas(rna_path, outfile,
         cmd += " --fragments_file %(fragments_file)s"
     if peak_annotation_file is not None and pd.notna(peak_annotation_file):
         cmd += " --peak_annotation_file %(peak_annotation_file)s"
-    if PARAMS['protein_metadata_table'] is not None:
-        cmd += " --protein_var_table %(protein_metadata_table)s"
-    if PARAMS['index_col_choice'] is not None:
-        cmd += " --protein_new_index_col %(index_col_choice)s"
       # ~ means this tests "is not nan"
     if tcr_path is not None and pd.notna(tcr_path):
         cmd += " --tcr_filtered_contigs %(tcr_path)s"
@@ -163,6 +159,10 @@ def concat_filtered_mudatas(infiles, outfile):
     if PARAMS["barcode_mtd_include"] is True:
         cmd += " --barcode_mtd_df %(barcode_mtd_path)s"
         cmd += " --barcode_mtd_metadatacols %(barcode_mtd_metadatacols)s"
+    if PARAMS['protein_metadata_table'] is not None:
+        cmd += " --protein_var_table %(protein_metadata_table)s"
+    if PARAMS['index_col_choice'] is not None:
+        cmd += " --protein_new_index_col %(index_col_choice)s"
     cmd += " > logs/concat_filtered_mudatas.log"
     job_kwargs["job_threads"] = PARAMS['resources_threads_high']
     P.run(cmd, **job_kwargs)

--- a/panpipes/python_scripts/make_adata_from_csv.py
+++ b/panpipes/python_scripts/make_adata_from_csv.py
@@ -67,12 +67,6 @@ parser.add_argument('--bcr_filetype',
 parser.add_argument('--output_file',
                     default=None,
                     help='')
-parser.add_argument('--protein_var_table',
-                    default=None,
-                    help='')
-parser.add_argument('--protein_new_index_col',
-                    default=None,
-                    help='')
 parser.add_argument('--per_barcode_metrics_file',
                     default=None,
                     help='ATAC/Multiome specific input file from csv')                    
@@ -123,31 +117,6 @@ if 'prot' in mdata.mod.keys():
             intersect_obs_by_mod(mdata, ['rna', 'prot'])
             mdata.update()
     L.info(mdata['prot'].var.head())
-    if args.protein_var_table is not None:
-        try:
-            df = pd.read_csv(args.protein_var_table, sep='\t', index_col=0)
-            L.info("merging protein table with var")
-            # add_var_mtd(mdata['prot'], df)
-            var_df = mdata['prot'].var.merge(df, left_index=True, right_index=True)
-            if args.protein_new_index_col is not None:
-                L.info("updating prot.var index")
-                # update_var_index(mdata['prot'], args.protein_new_index_col)
-                var_df =var_df.reset_index().set_index(args.protein_new_index_col)
-                var_df = var_df.rename(columns={'index':'orig_id'})
-                var_df.index.name = None
-            mdata['prot'].var = var_df
-            mdata.update_var()
-            mdata.update()
-            # we might want to split hashing antibodies into a separate modalities
-            # we assume this has been inidicated in a "hashing_ab" column in the protein metadata file
-            if "hashing_ab" in mdata['prot'].var.columns:
-                # create new modality for hashing
-                mdata.mod["hashing_ab"]=mdata["prot"][:, mdata["prot"].var["hashing_ab"]]
-                # subset old modality to remove hashing
-                mdata.mod['prot'] = mdata["prot"][:, ~mdata["prot"].var["hashing_ab"]]
-        except FileNotFoundError:
-            warnings.warn("protein metadata table not found")
-    mdata.update()
 
 if 'atac' in mdata.mod.keys():
     mdata['atac'].var_names_make_unique()


### PR DESCRIPTION
Hey @bio-la, I edited your favourite script 😉 

Turns out when you have multiple adt libraries which different ADT, the pipeline crashes when it tried to concatenate them, in the following specific sitattion:
- set concat type to outer in the qc_mm pipeline.yml
- merge in and adt metadata file with a TRUE FALSE column (e.g. isotype)

then the concatenated mudata cannot be written out because there is a mixture of TRUE/FALSE and NA is the same column and it can't deal with it.

We can get around this by merging in the adt information after we concatenate the object together, instead of merging the adt metadata with each individual h5mu in the tmp folder.

That is what is in this PR. 
