### PR TITLE
 fixed assess_background.py to account for unequal samples in rna & prot

### DIFF
--- a/panpipes/python_scripts/assess_background.py
+++ b/panpipes/python_scripts/assess_background.py
@@ -191,7 +191,7 @@ if 'rna' in mdata.mod.keys():
     plt.savefig(os.path.join(args.figpath,"scatter_bg_fg_rna_nGene_rna_nUMI.png"),transparent=False)
     if 'prot' in mdata.mod.keys():
         if n_samples_rna != n_samples_prot:
-            L.info("n_samples are not equal in rna and prot")
+            L.info("n_samples are not equal in rna and prot,taking intrsect for mdata and mdata_bg")
             mu.pp.intersect_obs(mdata_bg)
             mu.pp.intersect_obs(mdata)
             pnp.pl.scatter_fg_vs_bg(mdata, mdata_bg,x="prot:log1p_total_counts", y="rna:log1p_n_genes_by_counts", facet_row=args.channel_col)
@@ -201,7 +201,7 @@ if 'rna' in mdata.mod.keys():
             plt.subplots_adjust(right=0.7)
             plt.savefig(os.path.join(args.figpath,"scatter_bg_fg_rna_nUMI_prot_nUMI.png"),transparent=False)
         else:
-            L.info("n_samples are equal in rna and prot, taking intrsect for mdata and mdata_bg")
+            L.info("n_samples are equal in rna and prot")
             pnp.pl.scatter_fg_vs_bg(mdata, mdata_bg,x="prot:log1p_total_counts", y="rna:log1p_n_genes_by_counts", facet_row=args.channel_col)
             plt.subplots_adjust(right=0.7)
             plt.savefig(os.path.join(args.figpath, "scatter_bg_fg_prot_nUMI_rna_nGene.png"),transparent=False)

--- a/panpipes/python_scripts/assess_background.py
+++ b/panpipes/python_scripts/assess_background.py
@@ -119,24 +119,13 @@ if 'prot' in mdata.mod.keys():
 mdata.update()
 mdata_bg.update()
 
+n_samples_rna=len(mdata['rna'].obs['sample_id'].unique())
+n_samples_prot=len(mdata['prot'].obs['sample_id'].unique())
 
-## QC for gex and protein fcomparing foreground and background
+# quantifying the top background features
 if os.path.exists(args.figpath) is False:
     os.mkdirs(args.figpath)
 
-if 'rna' in mdata.mod.keys():
-    pnp.pl.scatter_fg_vs_bg(mdata, mdata_bg,x="rna:log1p_n_genes_by_counts", y="rna:log1p_total_counts", facet_row=args.channel_col)
-    plt.subplots_adjust(right=0.7)
-    plt.savefig(os.path.join(args.figpath,"scatter_bg_fg_rna_nGene_rna_nUMI.png"),transparent=False)
-    if 'prot' in mdata.mod.keys() :
-        pnp.pl.scatter_fg_vs_bg(mdata, mdata_bg,x="prot:log1p_total_counts", y="rna:log1p_n_genes_by_counts", facet_row=args.channel_col)
-        plt.subplots_adjust(right=0.7)
-        plt.savefig(os.path.join(args.figpath, "scatter_bg_fg_prot_nUMI_rna_nGene.png"),transparent=False)
-        pnp.pl.scatter_fg_vs_bg(mdata, mdata_bg,x="rna:log1p_total_counts", y="prot:log1p_total_counts", facet_row=args.channel_col)
-        plt.subplots_adjust(right=0.7)
-        plt.savefig(os.path.join(args.figpath,"scatter_bg_fg_rna_nUMI_prot_nUMI.png"),transparent=False)
-
-# quantifying the top background features
 if 'rna' in mdata.mod.keys():
     sc.pl.highest_expr_genes(mdata_bg['rna'],n_top=30, save="_rna_background.png")
     top_genes = pnp.scmethods.get_top_expressed_features(mdata_bg['rna'], n_top=30, group_by=args.channel_col)
@@ -155,6 +144,7 @@ if 'rna' in mdata.mod.keys():
         plt.savefig(os.path.join(args.figpath,"barplot_background_" + args.channel_col + "_rna_top_expressed.png"))
 
 
+# quantifying the top background features
 ## Repeat for protein (if it exists)
 if 'prot' in mdata.mod.keys():
     # this time we'll just use all the adts.
@@ -191,6 +181,35 @@ if 'prot' in mdata.mod.keys():
             pnp.plotting.adjust_x_axis(ax)
             fig.tight_layout()
         plt.savefig(os.path.join(args.figpath,"barplot_background_" + args.channel_col + "_prot_top_expressed.png"))
+
+
+## QC for gex and protein fcomparing foreground and background
+
+if 'rna' in mdata.mod.keys():
+    pnp.pl.scatter_fg_vs_bg(mdata, mdata_bg,x="rna:log1p_n_genes_by_counts", y="rna:log1p_total_counts", facet_row=args.channel_col)
+    plt.subplots_adjust(right=0.7)
+    plt.savefig(os.path.join(args.figpath,"scatter_bg_fg_rna_nGene_rna_nUMI.png"),transparent=False)
+    if 'prot' in mdata.mod.keys():
+        if n_samples_rna != n_samples_prot:
+            L.info("n_samples are not equal in rna and prot")
+            mu.pp.intersect_obs(mdata_bg)
+            mu.pp.intersect_obs(mdata)
+            pnp.pl.scatter_fg_vs_bg(mdata, mdata_bg,x="prot:log1p_total_counts", y="rna:log1p_n_genes_by_counts", facet_row=args.channel_col)
+            plt.subplots_adjust(right=0.7)
+            plt.savefig(os.path.join(args.figpath, "scatter_bg_fg_prot_nUMI_rna_nGene.png"),transparent=False)
+            pnp.pl.scatter_fg_vs_bg(mdata, mdata_bg,x="rna:log1p_total_counts", y="prot:log1p_total_counts", facet_row=args.channel_col)
+            plt.subplots_adjust(right=0.7)
+            plt.savefig(os.path.join(args.figpath,"scatter_bg_fg_rna_nUMI_prot_nUMI.png"),transparent=False)
+        else:
+            L.info("n_samples are equal in rna and prot, taking intrsect for mdata and mdata_bg")
+            pnp.pl.scatter_fg_vs_bg(mdata, mdata_bg,x="prot:log1p_total_counts", y="rna:log1p_n_genes_by_counts", facet_row=args.channel_col)
+            plt.subplots_adjust(right=0.7)
+            plt.savefig(os.path.join(args.figpath, "scatter_bg_fg_prot_nUMI_rna_nGene.png"),transparent=False)
+            pnp.pl.scatter_fg_vs_bg(mdata, mdata_bg,x="rna:log1p_total_counts", y="prot:log1p_total_counts", facet_row=args.channel_col)
+            plt.subplots_adjust(right=0.7)
+            plt.savefig(os.path.join(args.figpath,"scatter_bg_fg_rna_nUMI_prot_nUMI.png"),transparent=False)
+
+
 
 plt.clf()
 


### PR DESCRIPTION
hiya,
if there is an instance of unqueal samples (based on sample_id) for rna and prot, the script was erroring, because of the order of plots.

So I,
1) Changed the order of the plots, so that unimodal plots were done first (backgorund heatmap, top expressed plots for each modality)
2) The scatter plot for fg_vs_bg i moved to later, and only for the multimodal rna_vs_prot plots, if the n_samples between rna and prot are not the same, we take intersect of obs in rna and prot and then do the plots.

I have tested the script on my end and it worked fine for me.

Devika