### PR TITLE
Update pipeline_preprocess.py

### DIFF
--- a/panpipes/panpipes/pipeline_preprocess.py
+++ b/panpipes/panpipes/pipeline_preprocess.py
@@ -111,7 +111,7 @@ def downsample(log_file, filt_obj):
          --output_mudata %(filt_obj)s \
          --sampleprefix %(sample_prefix)s \
          --downsample_value %(downsample_n)s \
-         --batch_col %(downsample_col)s
+         --downsample_col %(downsample_col)s
          --intersect_mods %(downsample_mods)s
         """
         cmd += " > %(log_file)s  "


### PR DESCRIPTION
minor param type. in the `downsample.py` this param is `downsample_col`, where as in the ruffus statetment  in `pipeline_preprocess.py` for the python scripts its `batch_col`. I assume this should match up?