### PR TITLE
testing matplotlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "harmonypy", 
     "leidenalg", 
     "louvain",
-    "matplotlib",
+    "matplotlib<=3.7.3",
     "mofapy2",
     "mudata>=0.2.1",
     "muon",


### PR DESCRIPTION
matplotlib 3.8.0 was released on sep 13, so after this date installation of panpipes through `pip install panpipes` fetches this last version. This version causes issue #104 

setting matplotlib<=3.7.3  in .toml files fixes this issue.
verified by installing panpipes from this branch with `pip install -e .`

@crichgriffin can we fix a stable release with this older matplotlib version and work on the update in a future release?

thank you!