### PR TITLE
Update assess_background.py

### DIFF
--- a/panpipes/python_scripts/assess_background.py
+++ b/panpipes/python_scripts/assess_background.py
@@ -119,7 +119,8 @@ if 'prot' in mdata.mod.keys():
 mdata.update()
 mdata_bg.update()
 
-n_samples_rna=len(mdata['rna'].obs['sample_id'].unique())
+if 'rna' in mdata.mod.keys():
+    n_samples_rna=len(mdata['rna'].obs['sample_id'].unique())
 if "prot" in mdata.mod.keys():
     n_samples_prot=len(mdata['prot'].obs['sample_id'].unique())
 

--- a/panpipes/python_scripts/assess_background.py
+++ b/panpipes/python_scripts/assess_background.py
@@ -120,7 +120,8 @@ mdata.update()
 mdata_bg.update()
 
 n_samples_rna=len(mdata['rna'].obs['sample_id'].unique())
-n_samples_prot=len(mdata['prot'].obs['sample_id'].unique())
+if "prot" in mdata.mod.keys():
+    n_samples_prot=len(mdata['prot'].obs['sample_id'].unique())
 
 # quantifying the top background features
 if os.path.exists(args.figpath) is False:


### PR DESCRIPTION
a minor bug, that script fails if no prot modality present because sample_len also being calculated for prot modality. I  have wrapped this in an IF statment now for both `rna` and `prot` and tested the change