### PR TITLE
LSI recomputation panpipes_clustering

### DIFF
--- a/panpipes/funcs/scmethods.py
+++ b/panpipes/funcs/scmethods.py
@@ -23,6 +23,25 @@ import matplotlib
 import matplotlib.pyplot as plt
 
 
+def lsi(adata, num_components):
+    """
+    Runs LSI on adata.X and uses HVFs if adata.var["highly_variable"] is present. Otherwise, runs LSI on all features.
+
+    :param adata: anndata to run LSI on
+    :param num_components: number of components to compute
+    """
+
+    if "highly_variable" in adata.var.columns:
+        adata_hvfs = adata[:, adata.var["highly_variable"]]
+        mu.atac.tl.lsi(adata_hvfs, n_comps=num_components)
+        # save output to original anndata
+        adata.obsm["X_lsi"] = adata_hvfs.obsm['X_lsi']
+        adata.uns["lsi"] = adata_hvfs.uns['lsi']
+        adata.varm["LSI"] = np.zeros(shape=(adata.n_vars, adata_hvfs.varm["LSI"].shape[1]))
+        adata.varm["LSI"][adata.var["highly_variable"]] = adata_hvfs.varm['LSI']
+    else:
+        mu.atac.tl.lsi(adata, n_comps=num_components)
+
 
 def cell2loc_filter_genes(adata, fig_path, cell_count_cutoff=15, cell_percentage_cutoff2=0.05, nonz_mean_cutoff=1.12):
 # Adjusted from: https://github.com/BayraktarLab/cell2location/blob/master/cell2location/utils/filtering.py

--- a/panpipes/panpipes/pipeline_clustering/pipeline.yml
+++ b/panpipes/panpipes/pipeline_clustering/pipeline.yml
@@ -44,7 +44,7 @@ multimodal:
 
 
 # ---------------------------------------
-# parameters for find neighbours
+# parameters for finding neighbours
 # ---------------------------------------
 # 
 # -----------------------------
@@ -79,9 +79,9 @@ neighbors:
   atac:
     use_existing: True
     # which representation in .obsm to use for nearest neighbors
-    # if dim_red=X_lsi/X_pca and X_lis/X_pca not in .obsm, will be computed with default parameters
+    # if dim_red=X_lsi/X_pca and X_lsi/X_pca not in .obsm, will be computed with default parameters
     dim_red: X_lsi
-    # if dim_red=X_lsi/X_pca and X_lis/X_pca not in .obsm, which dimension to remove
+    # if dim_red=X_lsi/X_pca and X_lsi/X_pca not in .obsm, which dimension to remove
     dim_remove: 1
     #how many components to use for clustering
     n_dim_red: 30
@@ -230,7 +230,7 @@ markerspecs:
     threshuse: 0.25
 
 # ---------------------------------------
-# plot specs are used to define which metadata columns are used in the visualisations
+# plot specs are used to define which metadata columns are used in the visualizations
 # ---------------------------------------
 plotspecs:
   layers:

--- a/panpipes/panpipes/pipeline_clustering/pipeline.yml
+++ b/panpipes/panpipes/pipeline_clustering/pipeline.yml
@@ -23,7 +23,7 @@ condaenv:
 
 sample_prefix: mdata
 scaled_obj: mdata_scaled.h5mu
-# full obj only applicable if you have filtered your sacled object by hvgs
+# full obj only applicable if you have filtered your scaled object by hvgs
 # in this case panpipes will use the full obj to calculate rank_gene_groups and for plotting those genes
 # it should contain all the genes you want to include in rank_gene_groups, plus logged_counts as a layer
 # if your scaled_obj contains all the genes then leave full_obj blank
@@ -52,7 +52,8 @@ multimodal:
 neighbors:
   rna:
     use_existing: True
-    # number of Principal Components to calculate for neighbours and umap:
+    # which representation in .obsm to use for nearest neighbors
+    # if dim_red=X_pca and X_pca not in .obsm, will be computed with default parameters
     dim_red: X_pca
     #how many components to use for clustering
     n_dim_red: 30
@@ -64,7 +65,8 @@ neighbors:
     method: scanpy
   prot:
     use_existing: True
-    # number of Principal Components to calculate for neighbours and umap:
+    # which representation in .obsm to use for nearest neighbors
+    # if dim_red=X_pca and X_pca not in .obsm, will be computed with default parameters
     dim_red: X_pca
     #how many components to use for clustering
     n_dim_red: 30
@@ -76,8 +78,11 @@ neighbors:
     method: scanpy
   atac:
     use_existing: True
-    # number of Principal Components to calculate for neighbours and umap:
-    dim_red: X_pca
+    # which representation in .obsm to use for nearest neighbors
+    # if dim_red=X_lsi/X_pca and X_lis/X_pca not in .obsm, will be computed with default parameters
+    dim_red: X_lsi
+    # if dim_red=X_lsi/X_pca and X_lis/X_pca not in .obsm, which dimension to remove
+    dim_remove: 1
     #how many components to use for clustering
     n_dim_red: 30
     # number of neighbours
@@ -88,7 +93,8 @@ neighbors:
     method: scanpy
   spatial:
     use_existing: False
-    # number of Principal Components to calculate for neighbours and umap:
+    # which representation in .obsm to use for nearest neighbors
+    # if dim_red=X_pca and X_pca not in .obsm, will be computed with default parameters
     dim_red: X_pca
     #how many components to use for clustering
     n_dim_red: 30
@@ -162,7 +168,7 @@ clusterspecs:
 # ---------------------------------------
 # where pseudo_suerat is set to False 
 # we run https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.rank_genes_groups.html
-# where pseudo_seurat is set to True, we run an a python implementation of Seurat::FindMarkers (written by CRG)
+# where pseudo_seurat is set to True, we run a python implementation of Seurat::FindMarkers (written by CRG)
 
 markerspecs:
   rna:
@@ -173,7 +179,7 @@ markerspecs:
     mincells: 10 # if a cluster contains less than n cells then do not bother doing marker analysis
     # where pseudo_suerat is set to False 
     # we run https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.rank_genes_groups.html
-    # where pseudo_seurat is set to True, we run an a python implementation of Seurat::FindMarkers (written by CRG) is used,
+    # where pseudo_seurat is set to True, we run a python implementation of Seurat::FindMarkers (written by CRG),
     pseudo_seurat: False
     # these next two settings do not matter unless pseudo_seurat is set to True,
     # If applicable look at Seurat documentation for FindMarkers for details
@@ -216,7 +222,7 @@ markerspecs:
     mincells: 10 # if a cluster contains less than n cells then do not bother doing marker analysis
     # where pseudo_suerat is set to False 
     # we run https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.rank_genes_groups.html
-    # where pseudo_seurat is set to True, we run an a python implementation of Seurat::FindMarkers (written by CRG) is used,
+    # where pseudo_seurat is set to True, we run a python implementation of Seurat::FindMarkers (written by CRG),
     pseudo_seurat: False
     # these next two settings do not matter unless pseudo_seurat is set to True,
     # If applicable look at Seurat documentation for FindMarkers for details

--- a/panpipes/panpipes/pipeline_preprocess.py
+++ b/panpipes/panpipes/pipeline_preprocess.py
@@ -232,9 +232,10 @@ def atac_preprocess(log_file, scaled_file):
         cmd += " --dimred %(atac_dimred)s"
     else:    
         cmd += " --dimred PCA"
+    if PARAMS['atac_n_comps'] is not None:
+        cmd += " --n_comps %(atac_n_comps)s"
     if PARAMS['atac_dim_remove'] is not None:
         cmd += " --dim_remove %(atac_dim_remove)s"
-
     if PARAMS['atac_feature_selection_flavour'] is not None:
         cmd += " --feature_selection_flavour %(atac_feature_selection_flavour)s"
     if PARAMS['atac_min_cutoff'] is not None:
@@ -243,50 +244,6 @@ def atac_preprocess(log_file, scaled_file):
     cmd += " > %(log_file)s"
     job_kwargs["job_threads"] = PARAMS['resources_threads_high']
     P.run(cmd, **job_kwargs)
-
-
-'''
-@active_if(mode_dictionary['spatialT'] is True)
-@follows(atac_preprocess)
-@originate("logs/preprocess_spatialT.log", PARAMS['mudata_file'])
-def spatialT_preprocess(log_file, scaled_file):
-    if os.path.exists("figures/spatialT") is False:
-        os.mkdir("figures/spatialT")
-    cmd = """
-        python %(py_path)s/run_preprocess_spatialT.py
-        --input_mudata %(scaled_file)s
-        --output_mudata %(scaled_file)s
-        --figdir ./figures/spatialT
-        """
-    if PARAMS['spatialT_norm_hvg_flavour'] is not None:
-        cmd += " --norm_hvg_flavour %(spatialT_norm_hvg_flavour)s"
-    if PARAMS['spatialT_n_top_genes'] is not None:
-        cmd += " --n_top_genes %(spatialT_n_top_genes)s"
-    if PARAMS['spatialT_filter_by_hvg'] is True:
-        cmd += " --filter_by_hvg True"
-    else:
-        cmd += " --filter_by_hvg False"
-    if PARAMS['spatialT_hvg_batch_key'] is not None:
-        cmd += " --hvg_batch_key %(spatialT_hvg_batch_key)s"
-    if PARAMS['spatialT_squidpy_hvg_flavour'] is not None:
-        cmd += " --squidpy_hvg_flavour %(spatialT_squidpy_hvg_flavour)s"
-    if PARAMS['spatialT_min_mean'] is not None:
-        cmd += " --min_mean %(spatialT_min_mean)s"
-    if PARAMS['spatialT_max_mean'] is not None:
-        cmd += " --max_mean %(spatialT_max_mean)s"
-    if PARAMS['spatialT_min_disp'] is not None:
-        cmd += " --min_disp %(spatialT_min_disp)s"
-    if PARAMS['spatialT_theta'] is not None:
-        cmd += " --theta %(spatialT_theta)s"
-    if PARAMS['spatialT_clip'] is not None:
-        cmd += " --clip %(spatialT_clip)s"
-    if PARAMS['spatialT_n_pcs'] is not None:
-        cmd += " --n_pcs %(spatialT_n_pcs)s"
-
-    cmd += " > %(log_file)s"
-    job_kwargs["job_threads"] = PARAMS['resources_threads_high']
-    P.run(cmd, **job_kwargs)
-'''
 
 
 

--- a/panpipes/panpipes/pipeline_preprocess/pipeline.yml
+++ b/panpipes/panpipes/pipeline_preprocess/pipeline.yml
@@ -42,7 +42,6 @@ modalities:
   prot: False
   rep: False
   atac: False
-  #spatialT: True
 
 # Filtering
 # --------------------------
@@ -130,14 +129,6 @@ filtering:
     ## var filtering: (feature) fragment level filtering here
     var:    
       nucleosome_signal:
-  #------------------------------------------------------
- # spatial:
-  #------------------------------------------------------ 
-  #  obs:
-   #   min:
-    #    n_genes_by_counts:
-     # max:
-      #  total_counts:
 
 # Intersecting barcodes
 # ----------------------
@@ -170,7 +161,6 @@ plotqc:
   prot_metrics: total_counts,log1p_total_counts,n_adt_by_counts,pct_counts_isotype
   atac_metrics: 
   rep_metrics:
- # spatialT_metrics: total_counts
 
 
 
@@ -264,16 +254,17 @@ prot:
 # --------------------------
 atac:
   binarize: False
-  normalize: TFIDF
-  TFIDF_flavour: signac
+  normalize: TFIDF # "log1p" or "TFIDF"
+  # if normalize = "TFIDF", else leave blank:
+  TFIDF_flavour: signac # "signac", "logTF" or "logIDF"
 
   # highly variable feature selection:
   # HVF selection either with scanpy's pp.highly_variable_genes() function or a pseudo-FindTopFeatures() function of the signac package
   feature_selection_flavour: signac  # "signac" or "scanpy"
   # parameters for HVF flavour == "scanpy", leave the below blank to use defaults
-  min_mean:
-  max_mean:
-  min_disp:
+  min_mean: #default 0.05
+  max_mean: #default 1.5
+  min_disp: #default 0.5
   # parameter for HVF flavour == "signac"
   min_cutoff: q5
   # min_cutoff can be specified as follows:
@@ -285,6 +276,7 @@ atac:
 
   # which dimred to use
   dimred: LSI #PCA or LSI
+  n_comps: 50 # how many components to compute
   # which dimension to exclude from further processing (sometimes useful to remove PC/LSI_1  if it's associated to tech factors)
   # leave blank to retain all 
   dim_remove: 1

--- a/panpipes/python_scripts/rerun_find_neighbors_for_clustering.py
+++ b/panpipes/python_scripts/rerun_find_neighbors_for_clustering.py
@@ -54,9 +54,19 @@ for mod in neighbor_dict.keys():
         if (neighbor_dict[mod]['dim_red'] == "X_pca") and ("X_pca" not in adata.obsm.keys()):
             L.info("X_pca not found, computing it using default parameters")
             sc.tl.pca(adata)
-        if (neighbor_dict[mod]['dim_red'] == "X_lsi") and ("X_lsi" not in adata.obsm.keys()):
-            L.info("X_lsi not found, computing it using default parameters")
-            lsi(adata=adata, num_components=50)
+            if (mod == "atac") and (neighbor_dict[mod]['dim_remove'] is not None):
+                dimrem = int(neighbor_dict[mod]['dim_remove'])
+                adata.obsm['X_pca'] = adata.obsm['X_pca'][:, dimrem:]
+                adata.varm["PCs"] = adata.varm["PCs"][:, dimrem:]
+        if mod == "atac":
+            if (neighbor_dict[mod]['dim_red'] == "X_lsi") and ("X_lsi" not in adata.obsm.keys()):
+                L.info("X_lsi not found, computing it using default parameters")
+                lsi(adata=adata, num_components=50)
+                if neighbor_dict[mod]['dim_remove'] is not None:
+                    dimrem = int(neighbor_dict[mod]['dim_remove'])
+                    adata.obsm['X_lsi'] = adata.obsm['X_lsi'][:, dimrem:]
+                    adata.varm["LSI"] = adata.varm["LSI"][:, dimrem:]
+                    adata.uns["lsi"]["stdev"] = adata.uns["lsi"]["stdev"][dimrem:]
 
         # run command
         opts = dict(method=neighbor_dict[mod]['method'],

--- a/panpipes/python_scripts/rerun_find_neighbors_for_clustering.py
+++ b/panpipes/python_scripts/rerun_find_neighbors_for_clustering.py
@@ -6,6 +6,7 @@ import scanpy as sc
 from muon import MuData, read
 from panpipes.funcs.scmethods import run_neighbors_method_choice
 from panpipes.funcs.io import read_yaml
+from panpipes.funcs.scmethods import lsi
 
 L = logging.getLogger()
 L.setLevel(logging.INFO)
@@ -53,6 +54,10 @@ for mod in neighbor_dict.keys():
         if (neighbor_dict[mod]['dim_red'] == "X_pca") and ("X_pca" not in adata.obsm.keys()):
             L.info("X_pca not found, computing it using default parameters")
             sc.tl.pca(adata)
+        if (neighbor_dict[mod]['dim_red'] == "X_lsi") and ("X_lsi" not in adata.obsm.keys()):
+            L.info("X_lsi not found, computing it using default parameters")
+            lsi(adata=adata, num_components=50)
+
         # run command
         opts = dict(method=neighbor_dict[mod]['method'],
                     n_neighbors=int(neighbor_dict[mod]['k']),

--- a/panpipes/python_scripts/run_preprocess_atac.py
+++ b/panpipes/python_scripts/run_preprocess_atac.py
@@ -28,6 +28,7 @@ L.debug("testing logger works")
 
 from panpipes.funcs.scmethods import X_is_raw
 from panpipes.funcs.scmethods import findTopFeatures_pseudo_signac
+from panpipes.funcs.scmethods import lsi
 
 
 sc.settings.verbosity = 3
@@ -64,6 +65,9 @@ parser.add_argument("--min_disp",
 parser.add_argument("--dimred",
                     default="PCA",
                     help="which dimensionality red to use for atac")
+parser.add_argument("--n_comps",
+                    default=50,
+                    help="how many components to compute")
 parser.add_argument("--dim_remove",
                     default=None,
                     help="which dimensionality red components to remove")
@@ -132,9 +136,9 @@ else:
 #highly variable feature selection
 
 if args.feature_selection_flavour == "scanpy":
-	sc.pp.highly_variable_genes(atac, min_mean=float(args.min_mean), max_mean=float(args.max_mean), min_disp=float(args.min_disp))
+    sc.pp.highly_variable_genes(atac, min_mean=float(args.min_mean), max_mean=float(args.max_mean), min_disp=float(args.min_disp))
 elif args.feature_selection_flavour == "signac":
-	findTopFeatures_pseudo_signac(atac, args.min_cutoff)
+    findTopFeatures_pseudo_signac(atac, args.min_cutoff)
 else:
     L.warning("No highly variable feature selection was performed!")
 
@@ -150,9 +154,9 @@ if "highly_variable" in atac.var:
 if args.dimred == "PCA":
     sc.pp.scale(atac)
     atac.layers["scaled_counts"] = atac.X.copy()
-    sc.tl.pca(atac, n_comps=min(50,atac.var.shape[0]-1), svd_solver='arpack', random_state=0) 
+    sc.tl.pca(atac, n_comps=int(args.n_comps), svd_solver='arpack', random_state=0)
 if args.dimred == "LSI":
-    ac.tl.lsi(atac)
+    lsi(adata=atac, num_components=int(args.n_comps))
 
 if args.dim_remove is not None:
     dimrem=int(args.dim_remove)


### PR DESCRIPTION
Added the recomputation of the LSI for the ATAC modality to _panpipes_clustering_. Also added the _dim_remove_ parameter only for ATAC and for both, LSI and PCA, the same way as in _panpipes_preprocess_: https://github.com/DendrouLab/panpipes/blob/main/panpipes/python_scripts/run_preprocess_atac.py