### PR TITLE
Small code fixes in panpipes_ingest

### DIFF
--- a/panpipes/panpipes/pipeline_ingest.py
+++ b/panpipes/panpipes/pipeline_ingest.py
@@ -313,6 +313,7 @@ def concat_bg_mudatas(infiles, outfile):
 
 def orfile():
     return PARAMS['sample_prefix'] + "_cell_metadata.tsv"
+@active_if(PARAMS["scr_run"])
 @active_if(PARAMS['modalities_rna'])
 @active_if(PARAMS["use_existing_h5mu"] is False)
 @follows(mkdir("scrublet"))

--- a/panpipes/python_scripts/run_scanpyQC_rna.py
+++ b/panpipes/python_scripts/run_scanpyQC_rna.py
@@ -159,6 +159,8 @@ if args.ccgenes is not None:
 
 L.info("calculated scores and metrics")
 
+mdata.update()
+
 L.info("saving anndata and obs in a metadata tsv file")
 write_obs(mdata, output_prefix=args.sampleprefix, 
         output_suffix="_cell_metadata.tsv")


### PR DESCRIPTION
Fixed two small bugs in panpipes_ingest. 
The mdata wasn't updated in run_scanpyQC_rna.py, so no QC metrics were saved in <sampleid>_unfilt.h5mu.
Added `@active_if(PARAMS["scr_run"])`, so that scrublet is only run when it is specified in the yaml to run it. 