### PR TITLE
Create spatial YAML doc files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Releases
 
 ### added
 
+- added Tangram to `deconvolution_spatial`
+
 ### fixed
 
 - fixed error in `vis`

--- a/docs/install.md
+++ b/docs/install.md
@@ -44,7 +44,7 @@ If you intend to use panpipes for spatial analysis, instead install:
 ```
 pip install 'panpipes[spatial]'
 ```
-The extra `[spatial]` includes squidpy and cell2location packages.
+The extra `[spatial]` includes squidpy, cell2location, and tangram-sc packages.
 
 
 #### 2. Nightly versions of panpipes.

--- a/docs/workflows/deconvolute_spatial.md
+++ b/docs/workflows/deconvolute_spatial.md
@@ -3,7 +3,7 @@ Deconvoluting spatial data
 
 With the `deconvolution_spatial` workflow, one or multiple spatial slides can be deconvoluted in one run. For that, a `MuData` object for each slide is expected, with the spatial data saved in `mdata.mod["spatial"]`. The spatial slides are deconvoluted using the same reference. For the reference, one `MuData` with the gene expression data saved in `mdata.mod["rna"]` is expected as input. 
 
-For now, the workflow provides the possibility to run deconvolution using `Cell2Location`.
+For now, the workflow provides the possibility to run deconvolution using `Cell2Location` and `Tangram`.
 
 
 
@@ -12,14 +12,28 @@ For now, the workflow provides the possibility to run deconvolution using `Cell2
 For the reference and each spatial slide the following steps are run. **Note, that if multiple slides are deconvoluted in one run, the same parameter setting is used for each slide.** 
 
 - Gene selection. There are two possibilities for the gene selection: 
-    - Genes of a user-provided feature set (csv-file) are used for deconvolution. All genes of that gene list need to be present in both, spatial slides and scRNA-Seq reference.
-    - Feature selection performed according to Cell2Location, i.e. via the function: `cell2location.utils.filtering.filter_genes`
-    - **Note**: if no csv-file is provided by the user, the workflow will run the feature selection via the function: `cell2location.utils.filtering.filter_genes`. Thus, gene selection is **not optional**.  
+    1. Genes of a user-provided feature set (csv-file) are used for deconvolution. All genes of that gene list need to be present in both, spatial slides and scRNA-Seq reference.
+    2. Feature selection performed according to Cell2Location, i.e. via the function: `cell2location.utils.filtering.filter_genes`
+    
+    **Note**: if no csv-file is provided by the user, the workflow will run the feature selection via the function: `cell2location.utils.filtering.filter_genes`. Thus, gene selection is **not optional**.  
 - Regression/reference model is fitted and a plot of the training history as well as QC plots are saved in the `./figures/Cell2Location` directory. Additionally, a csv-file `Cell2Loc_inf_anver.csv` with the estimated expression of every gene in every cell type is saved in `./cell2location.output`.
 - (Optional) Reference model is saved in `./cell2location.output`
 - Spatial mapping model is fitted. Training history and QC plots are saved in the `./figures/Cell2Location` directory. Plots of the spatial embedding coloured by `q05_cell_abundance_w_sf` is also saved in `./figures/Cell2Location`.
 - (Optional) Spatial mapping model is saved in `./cell2location.output`
 - `MuData` objects of the spatial slide and the reference are saved in `./cell2location.output`. The `MuData` object of the spatial slide contains the estimated cell type abundances.
+
+### Tangram
+For the reference and each spatial slide the following steps are run. **Note, that if multiple slides are deconvoluted in one run, the same parameter setting is used for each slide.** 
+
+- Gene selection with two possibilities: 
+    1. Genes of a user-provided feature set (csv-file) are used for deconvolution. All genes of that gene list need to be present in both, spatial slides and scRNA-Seq reference.
+    2. [sc.tl.rank_genes_groups]() is used to select genes. The top n genes of each group make up the reduced gene set. 
+    
+    **Note**: if no csv-file is provided by the user, the workflow will run the feature selection via [sc.tl.rank_genes_groups](). Thus, gene selection is **not optional**.  
+- `AnnData` objects are preprocessed with [tangram.pp_adatas]()
+
+
+-----TODO-----
 
 
 ## Steps to run

--- a/docs/yaml_docs/spatial_deconvolution.md
+++ b/docs/yaml_docs/spatial_deconvolution.md
@@ -1,0 +1,123 @@
+
+# Spatial Deconvolution YAML
+
+In this documentation, the parameters of the `deconvolution_spatial` yaml file are explained. In general, the user can leave parameters empty to use defaults. <br> The individual steps run by the pipeline are described in the [spatial deconvolution workflow](../workflows/deconvolute_spatial.md). 
+
+
+
+## 0. Compute Resource Options
+
+| `resources` |  |
+| --- | --- |
+| `threads_high` | __`int`__ (default: 1) <br> Number of threads used for high intensity computing tasks. |
+| `threads_medium` | __`int`__ (default: 1) <br> Number of threads used for medium intensity computing tasks. For each thread, there must be enough memory to load your mudata and do computationally light tasks. |
+| `threads_low` | __`int`__ (default: 1) <br> Number of threads used for low intensity computing tasks. For each thread, there must be enough memory to load text files and do plotting, requires much less memory than the other two.|
+
+|  |  |
+| ---- | --- |
+| `condaenv` | __`str`__ (default: None) <br> Path to conda environment that should be used to run `Panpipes`. Leave blank if running native or your cluster automatically inherits the login node environment. |
+
+
+## 1. Input Options
+With the `deconvolution_spatial` workflow, one or multiple spatial slides can be deconvoluted in one run. For that, a `MuData` object for each slide is expected, with the spatial data saved in `mdata.mod["spatial"]`. The spatial slides are deconvoluted **using the same reference**. For the reference, one `MuData` with the gene expression data saved in `mdata.mod["rna"]` is expected as input. Please note, that the same parameter setting is used for each slide. <br> For the **spatial** input, the workflow, therefore, reads in **all `.h5mu` objects of a directory** (see below). **The spatial and single-cell data thus need to be saved in different folders.**
+
+| `input` |  |
+| ---- | --- |
+| `spatial` | __`str`__ (not optional) <br> Path to folder containing one or multiple `MuDatas` of spatial data. The pipeline is reading in all `MuData` files in that folder and assuming that they are `MuDatas` of spatial slides.|
+| `singlecell` | __`str`__ (not optional) <br> Path to the MuData **file** (not folder) of the reference single-cell data.|
+
+## 2. Cell2Location Options
+
+For each deconvolution method you can specify whether to run it or not: 
+| |  |
+| ---- | --- |
+| `run` | __`bool`__ (default: None) <br> Whether to run Cell2location|
+
+### Feature Selection 
+
+You can select genes that are used for deconvolution in two ways. The first option is to provide a reduced feature set as a csv-file that is then used for deconvolution. The second option is to perform gene selection [according to Cell2Location](https://cell2location.readthedocs.io/en/latest/cell2location.utils.filtering.html). <br> Please note, that gene selection is **not optional**. If no csv-file is provided, feature selection [according to Cell2Location.](https://cell2location.readthedocs.io/en/latest/cell2location.utils.filtering.html) is performed. 
+
+
+| `feature_selection` |  |
+| ---- | --- |
+| `gene_list` | __`str`__ (default: None) <br>  Path to a csv file containing a reduced feature set. A header in the csv is expected in the first row. All genes of that gene list need to be present in both, spatial slides and scRNA-Seq reference.|
+| `remove_mt` | __`bool`__ (default: True) <br> Whether to remove mitochondrial genes from the dataset. This step is performed **before** running gene selection. |
+| `cell_count_cutoff` | __`int`__ (default: 15) <br> All genes detected in less than cell_count_cutoff cells will be excluded. Parameter of the [Cell2Location's gene selection function.](https://cell2location.readthedocs.io/en/latest/cell2location.utils.filtering.html)|
+| `cell_percentage_cutoff2` | __`float`__ (default: 0.05) <br> All genes detected in at least this percentage of cells will be included. Parameter of the [Cell2Location's gene selection function.](https://cell2location.readthedocs.io/en/latest/cell2location.utils.filtering.html)|
+| `nonz_mean_cutoff` | __`float`__ (default: 1.12) <br> Genes detected in the number of cells between the above-mentioned cutoffs are selected only when their average expression in non-zero cells is above this cutoff.  Parameter of the [Cell2Location's gene selection function.](https://cell2location.readthedocs.io/en/latest/cell2location.utils.filtering.html) | 
+
+
+### Reference Model
+
+| `reference` |  |
+| ---- | --- |
+| `labels_key` | __`str`__ (default: None) <br> Key in `.obs` for label (cell type) information. |
+| `batch_key` | __`str`__ (default: None) <br> Key in `.obs` for batch information. |
+| `layer` | __`float`__ (default: None) <br> Layer in `.layers` to use for the reference model. If None, `.X` will be used. Please note, that Cell2Location expects raw counts as input.|
+| `categorical_covariate_keys` | __`str`__ (default: None) <br> Comma-separated without spaces, e.g. _key1,key2,key3_. Keys in `.obs` that correspond to categorical data. These covariates can be added in addition to the batch covariate and are also treated as nuisance factors (i.e., the model tries to minimize their effects on the latent space).| 
+| `continuous_covariate_keys` | __`str`__ (default: None) <br> Comma-separated without spaces, e.g. _key1,key2,key3_. Keys in `.obs` that correspond to continuous data. These covariates can be added in addition to the batch covariate and are also treated as nuisance factors (i.e., the model tries to minimize their effects on the latent space)| 
+| `max_epochs` | __`int`__ (default: _np.min([round((20000 / n_cells) * 400), 400])_) <br> Number of epochs.| 
+| `use_gpu` | __`bool`__ (default: True) <br> Whether to use GPU for training. | 
+
+
+### Spatial Model 
+
+
+| `spatial` |  |
+| ---- | --- |
+| `batch_key` | __`str`__ (default: None) <br> Key in `.obs` for batch information. |
+| `layer` | __`float`__ (default: None) <br> Layer in `.layers` to use for the reference model. If None, `.X` will be used. Please note, that Cell2Location expects raw counts as input.|
+| `categorical_covariate_keys` | __`str`__ (default: None) <br> Comma-separated without spaces, e.g. _key1,key2,key3_. Keys in `.obs` that correspond to categorical data. These covariates can be added in addition to the batch covariate and are also treated as nuisance factors (i.e., the model tries to minimize their effects on the latent space).| 
+| `continuous_covariate_keys` | __`str`__ (default: None) <br> Comma-separated without spaces, e.g. _key1,key2,key3_. Keys in `.obs` that correspond to continuous data. These covariates can be added in addition to the batch covariate and are also treated as nuisance factors (i.e., the model tries to minimize their effects on the latent space)| 
+| `N_cells_per_location` | __`int`__ (not optional) <br> Expected cell abundance per voxel. Please refer to the [Cell2Location documentation](https://cell2location.readthedocs.io/en/latest/index.html) for more information. | 
+| `detection_alpha` | __`float`__ (not optional) <br> Regularization of with-in experiment variation in RNA detection sensitivity. Please refer to the [Cell2Location documentation](https://cell2location.readthedocs.io/en/latest/index.html) for more information.  | 
+| `max_epochs` | __`int`__ (default: _np.min([round((20000 / n_cells) * 400), 400])_) <br> Number of epochs.| 
+| `use_gpu` | __`bool`__ (default: True) <br> Whether to use GPU for training. | 
+
+
+###
+<br>
+You can specify whether both models should be saved with the following parameter: 
+
+| |  |
+| ---- | --- |
+| `save_models` | __`bool`__ (default: False) <br> Whether to save the reference & spatial mapping models|
+
+
+
+
+## 3. Tangram Options
+
+For each deconvolution method you can specify whether to run it or not: 
+| |  |
+| ---- | --- |
+| `run` | __`bool`__ (default: None) <br> Whether to run Tangram|
+
+
+### Feature Selection
+
+You can select genes that are used for deconvolution in two ways. The first option is to provide a reduced feature set as a csv-file that is then used for deconvolution. The second option is to perform gene selection via [scanpy.tl.rank_genes_groups](https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.rank_genes_groups.html) **on the reference scRNA-Seq data**, as [suggested by Tangram](https://tangram-sc.readthedocs.io/en/latest/tutorial_sq_link.html#Pre-processing). The top `n_genes` of each group make up the reduced gene set. <br> Please note, that gene selection is **not optional**. If no csv-file is provided, feature selection via [scanpy.tl.rank_genes_groups](https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.rank_genes_groups.html) is performed. 
+
+
+| `feature_selection` |  |
+| ---- | --- |
+| `gene_list` | __`str`__ (default: None) <br>  Path to a csv file containing a reduced feature set. A header in the csv is expected in the first row. All genes of that gene list need to be present in both, spatial slides and scRNA-Seq reference.|
+
+___Parameters for `scanpy.tl.rank_genes_groups` gene selection___ 
+| `rank_genes` |  |
+| ---- | --- |
+| `labels_key` | __`str`__ (default: None) <br> Which column in `.obs` of the reference to use for the `groupby` parameter of [scanpy.tl.rank_genes_groups](https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.rank_genes_groups.html) .|
+| `layer` | __`str`__ (default: None) <br> Which layer of the reference to use for [scanpy.tl.rank_genes_groups](https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.rank_genes_groups.html). If None, `.X` is used.|
+| `n_genes` | __`int`__ (default: 100) <br> How many top genes to select of each `groupby` group|
+| `test_method` | __`str ['logreg', 't-test', 'wilcoxon', 't-test_overestim_var']`__ (default: 't-test_overestim_var') <br> Which test method to use.|
+| `correction_method` | __`str ['benjamini-hochberg', 'bonferroni']`__ (default: ' benjamini-hochberg') <br> Which p-value correction method to use. Used only for 't-test', 't-test_overestim_var', and 'wilcoxon'. |
+
+### Model
+
+| `model` |  |
+| ---- | --- |
+| `labels_key` | __`str`__ (default: None) <br> Key in `.obs` for label (cell type) information. |
+| `num_epochs` | __`int`__ (default: 1000) <br> Number of epochs. | 
+| `device` | __`str`__ (default: 'cpu') <br> Which device to use. | 
+| `kwargs` | In `kwargs`, the user has the possibility to specify parameters for [tangram.mapping_utils.map_cells_to_space](https://tangram-sc.readthedocs.io/en/latest/classes/tangram.mapping_utils.map_cells_to_space.html?highlight=mapping_utils%20map_cells_to_space#tangram.mapping_utils.map_cells_to_space). You can add or remove any parameters of the function.| 
+

--- a/docs/yaml_docs/spatial_preprocess.md
+++ b/docs/yaml_docs/spatial_preprocess.md
@@ -1,0 +1,46 @@
+
+# Spatial preprocessing yaml
+
+In this documentation, the parameters of the `preprocess_spatial` yaml file are explained. In general, the user can leave parameters empty to use defaults. <br> To understand the individual steps run by the pipeline, please refer to the [spatial preprocess workflow](). 
+
+
+
+## 0. Compute resource options
+
+| `resources` |  |
+| --- | --- |
+| `threads_high` | __`int`__ (default: 1) <br> Number of threads used for high intensity computing tasks. |
+| `threads_medium` | __`int`__ (default: 1) <br> Number of threads used for medium intensity computing tasks. For each thread, there must be enough memory to load your mudata and do computationally light tasks. |
+| `threads_low` | __`int`__ (default: 1) <br> Number of threads used for low intensity computing tasks. For each thread, there must be enough memory to load text files and do plotting, requires much less memory than the other two.|
+
+|  |  |
+| ---- | --- |
+| `condaenv` | __`str`__ (default: None) <br> Path to conda environment that should be used to run `Panpipes`. Leave blank if running native or your cluster automatically inherits the login node environment. |
+
+
+## 1. Input options
+
+With the preprocess_spatial workflow, one or multiple `MuData` objects can be preprocessed in one run. The workflow reads in all `.h5mu` objects of a directory. The `MuData` objects in the directory need to be of the same assay (vizgen or visium). The workflow then runs the preprocessing of each `MuData` object separately with the same parameters that are specified in the yaml file. 
+
+| |  |
+| ---- | --- |
+| `input_dir` | __`str`__ (not optional) <br> Path to the folder containing all input `h5mu` files. |
+| `assay` | __`str` [`"visium"`, `"vizgen"`]__ (default: "visium") <br> Spatial transcriptomics assay of the `h5mu` files in `input_dir`.|
+
+
+## 2. Filtering options
+
+
+| `filtering` |  |
+| --- | --- |
+| `run` | __`bool`__ (default: False) <br> Whether to run filtering. If `False` will not filter the data and will not produce post-filtering plots. |
+| `keep_barcodes` | __`str`__ (default: None) <br> Path to a csv-file that has no header containing barcodes you want to keep. Barcodes that are not in the file, will be removed from the dataset. |
+
+
+____________
+
+------TODO-------
+
+
+
+

--- a/docs/yaml_docs/spatial_preprocess.md
+++ b/docs/yaml_docs/spatial_preprocess.md
@@ -98,7 +98,6 @@ ___Parameters for both `norm_hvg_flavour` flavours___
 | `filter_by_hvg` | __`bool`__ (default: False) <br> Subset the data to the HVGs. <br>  |
 | `hvg_batch_key` | __`str`__ (default: None) <br> If specified, HVGs are selected within each batch separately and merged. |
 
-<br>
 
 ### **PCA**
 

--- a/docs/yaml_docs/spatial_preprocess.md
+++ b/docs/yaml_docs/spatial_preprocess.md
@@ -1,11 +1,11 @@
 
-# Spatial preprocessing yaml
+# Spatial Preprocessing YAML
 
-In this documentation, the parameters of the `preprocess_spatial` yaml file are explained. In general, the user can leave parameters empty to use defaults. <br> To understand the individual steps run by the pipeline, please refer to the [spatial preprocess workflow](). 
+In this documentation, the parameters of the `preprocess_spatial` yaml file are explained. In general, the user can leave parameters empty to use defaults. <br> The individual steps run by the pipeline are described in the [spatial preprocess workflow](../workflows/preprocess_spatial.md). 
 
 
 
-## 0. Compute resource options
+## 0. Compute Resource Options
 
 | `resources` |  |
 | --- | --- |
@@ -18,29 +18,93 @@ In this documentation, the parameters of the `preprocess_spatial` yaml file are 
 | `condaenv` | __`str`__ (default: None) <br> Path to conda environment that should be used to run `Panpipes`. Leave blank if running native or your cluster automatically inherits the login node environment. |
 
 
-## 1. Input options
+## 1. Input Options
 
-With the preprocess_spatial workflow, one or multiple `MuData` objects can be preprocessed in one run. The workflow reads in all `.h5mu` objects of a directory. The `MuData` objects in the directory need to be of the same assay (vizgen or visium). The workflow then runs the preprocessing of each `MuData` object separately with the same parameters that are specified in the yaml file. 
+With the preprocess_spatial workflow, one or multiple `MuData` objects can be preprocessed in one run. The workflow **reads in all `.h5mu` objects of a directory**. The `MuData` objects in the directory need to be of the same assay (vizgen or visium). The workflow then runs the preprocessing of each `MuData` object separately with the same parameters that are specified in the yaml file. 
 
 | |  |
 | ---- | --- |
 | `input_dir` | __`str`__ (not optional) <br> Path to the folder containing all input `h5mu` files. |
-| `assay` | __`str` [`"visium"`, `"vizgen"`]__ (default: "visium") <br> Spatial transcriptomics assay of the `h5mu` files in `input_dir`.|
+| `assay` | __`str` [`'visium'`, `'vizgen'`]__ (default: 'visium') <br> Spatial transcriptomics assay of the `h5mu` files in `input_dir`.|
 
 
-## 2. Filtering options
+## 2. Filtering Options
 
 
 | `filtering` |  |
+| --- | --- | 
+| `run` | __`bool`__ (default: False) <br> Whether to run filtering. **If `False`, will not filter the data and will not produce post-filtering plots.** |  
+| `keep_barcodes` | __`str`__ (default: None) <br> Path to a csv-file that has **no header** containing barcodes you want to keep. Barcodes that are not in the file, will be removed from the dataset before filtering the dataset with the thresholds specified below. |
+
+
+With the parameters below you can specify thresholds for filtering. The filtering is fully customisable to any columns in `.obs` or `.var`. You are not restricted by the columns given as default. When specifying a column name, please make sure it exactly matches the column name in the h5mu object. <br> Please slso make sure, that the specified metrics are present in all `h5mu` objects of the `input_dir`, i.e. the `MuData` objects for that the preprocessing is run.
+
+
+---
+    spatial:
+        obs:
+            min:
+                total_counts: 
+            max:
+                pct_counts_mt:
+            bool: 
+        var:
+            min:
+                n_cells_by_counts: 
+            max:
+                total_counts:
+---
+
+
+## 3. Post-Filter Plotting
+
+The parameters below specify which metrics of the filtered data to plot. As for the [QC](./spatial_qc.md), violin and spatial embedding plots are generated for each slide separately. 
+
+| `plotqc` |  |
+| --- | --- | 
+| `grouping_var` | __`str`__ (default: None) <br>  Comma-separated string without spaces, e.g. _sample_id,batch_ of categorical columns in `.obs`. One violin will be created for each group in the violin plot. Not mandatory, can be left empty. |  
+| `spatial_metrics` | __`str`__ (default: None) <br>  Comma-separated string without spaces, e.g. _total_counts,n_genes_by_counts_ of columns in `.obs` or `.var`. <br>Specifies which metrics to plot. If metric is present in both, `.obs` and `.var`, **both will be plotted.** |
+
+
+## 4. Normalization, HVG Selection, and PCA Options
+
+### **Normalization and HVG Selection** <br>
+
+`Panpipes` offers two different normalization and HVG selection flavours, `'seurat'` and `'squidpy'`. <br> The `'seurat'`  flavour first selects HVGs on the raw counts using analytic Pearson residuals, i.e. [scanpy.experimental.pp.highly_variable_genes](https://scanpy.readthedocs.io/en/stable/generated/scanpy.experimental.pp.highly_variable_genes.html). Afterwards, analytic Pearson residual normalization is applied, i.e. [scanpy.experimental.pp.normalize_pearson_residuals](https://scanpy.readthedocs.io/en/stable/generated/scanpy.experimental.pp.normalize_pearson_residuals.html). Parameters of both functions can be specified by the user in the yaml file. <br>The `'squidpy'` flavour runs the basic scanpy normalization and HVG selection functions, i.e. [scanpy.pp.normalize_total](https://scanpy.readthedocs.io/en/stable/generated/scanpy.pp.normalize_total.html), [scanpy.pp.log1p](https://scanpy.readthedocs.io/en/stable/generated/scanpy.pp.log1p.html), and [scanpy.pp.highly_variable_genes](https://scanpy.readthedocs.io/en/stable/generated/scanpy.pp.highly_variable_genes.html). <br> 
+
+
+| `spatial` |  |
 | --- | --- |
-| `run` | __`bool`__ (default: False) <br> Whether to run filtering. If `False` will not filter the data and will not produce post-filtering plots. |
-| `keep_barcodes` | __`str`__ (default: None) <br> Path to a csv-file that has no header containing barcodes you want to keep. Barcodes that are not in the file, will be removed from the dataset. |
+| `norm_hvg_flavour` | __`str` [`'squidpy'`, `'seurat'`]__ (default: None) <br>  Normalization and HVG selection flavour to use. If None, will not run normalization nor HVG selection. | 
 
+___Parameters for `norm_hvg_flavour` == `'squidpy'`___ 
+| |  |
+| --- | --- |
+| `squidpy_hvg_flavour` | __`str` [`'seurat'`,`'cellranger'`,`'seurat_v3'`]__ (default: 'seurat') <br>   Flavour to select HVGs, i.e.`flavor` parameter of the function [scanpy.pp.highly_variable_genes](https://scanpy.readthedocs.io/en/stable/generated/scanpy.pp.highly_variable_genes.html).|
+| `min_mean` | __`float`__ (default: 0.05) <br>  Parameter in [scanpy.pp.highly_variable_genes](https://scanpy.readthedocs.io/en/stable/generated/scanpy.pp.highly_variable_genes.html).|
+| `max_mean` | __`float`__ (default: 1.5) <br>  Parameter in [scanpy.pp.highly_variable_genes](https://scanpy.readthedocs.io/en/stable/generated/scanpy.pp.highly_variable_genes.html). |
+| `min_disp` | __`float`__ (default: 0.5) <br>  Parameter in [scanpy.pp.highly_variable_genes](https://scanpy.readthedocs.io/en/stable/generated/scanpy.pp.highly_variable_genes.html). |
 
-____________
+___Parameters for `norm_hvg_flavour` == `'seurat'`___ 
+| |  |
+| --- | --- |
+| `theta` | __`float`__ (default: 100) <br>  The negative binomial overdispersion parameter for pearson residuals. The same value is used for [HVG selection]((https://scanpy.readthedocs.io/en/stable/generated/scanpy.experimental.pp.highly_variable_genes.html)) and [normalization](https://scanpy.readthedocs.io/en/stable/generated/scanpy.experimental.pp.normalize_pearson_residuals.html).  |
+| `clip` | __`float`__ (default: None) <br> Specifies clipping of the residuals. <br>`clip` can be specified as: <br> <ul><li> <u>None</u>: residuals are clipped to the interval [-sqrt(n_obs), sqrt(n_obs)] </li><li><u>A float value</u>: if float c specified: clipped to the interval [-c, c]</li> <li> <u>np.Inf</u>: no clipping</li></ul> | 
 
-------TODO-------
+___Parameters for both `norm_hvg_flavour` flavours___ 
+| |  |
+| --- | --- |
+| `n_top_genes` | __`int`__ (default: 2000) <br> Number of genes to select. Mandatory for `norm_hvg_flavour='seurat'` and `squidpy_hvg_flavour='seurat_v3'`.|
+| `filter_by_hvg` | __`bool`__ (default: False) <br> Subset the data to the HVGs. <br>  |
+| `hvg_batch_key` | __`str`__ (default: None) <br> If specified, HVGs are selected within each batch separately and merged. |
 
+<br>
 
+### **PCA**
 
+After normalization and HVG selection, PCA is run and the PCA and elbow plot are plotted. For that, the user can specify the number of PCs for the PCA computation and for the elbow plot, i.e. the same number is used for both. 
+
+| |  |
+| --- | --- |
+| `n_pcs` | __`int`__ (default: 50) <br> Number of PCs to compute. |
 

--- a/docs/yaml_docs/spatial_qc.md
+++ b/docs/yaml_docs/spatial_qc.md
@@ -1,0 +1,48 @@
+
+# Spatial QC yaml 
+
+In this documentation, the parameters of the `qc_spatial` yaml file are explained. In general, the user can leave parameters empty to use defaults. <br> To understand the individual steps run by the pipeline, please refer to the [spatial QC workflow](). 
+
+
+
+## 0. Compute resource options
+
+| `resources` |  |
+| --- | --- |
+| `threads_high` | __`int`__ (default: 1) <br> Number of threads used for high intensity computing tasks. For each thread, there must be enough memory to load all input files and create MuDatas.  |
+| `threads_medium` | __`int`__ (default: 1) <br> Number of threads used for medium intensity computing tasks. For each thread, there must be enough memory to load your mudata and do computationally light tasks. |
+| `threads_low` | __`int`__ (default: 1) <br> Number of threads used for low intensity computing tasks. For each thread, there must be enough memory to load text files and do plotting, requires much less memory than the other two.|
+
+
+
+|  |  |
+| ---- | --- |
+| `condaenv` | __`str`__ (default: None) <br> Path to conda environment that should be used to run `Panpipes`. Leave blank if running native or your cluster automatically inherits the login node environment |
+
+
+
+
+## 1. Loading options 
+
+|  |  |
+| ---- | --- |
+| `project` | __`str`__ (default: None) <br> Project name |
+| `submission_file` | __`str`__ (not optional) <br> Path to the submission file. The submission file specifies the input files. Please refer to the [general guidelines]() for details on the format of the file. |
+
+
+## 2. QC options 
+This part of the workflow allows to generate additional QC metrics that can be used for filtering/preprocessing. Basic QC metrics using [scanpy.pp.calculate_qc_metrics](https://scanpy.readthedocs.io/en/stable/generated/scanpy.pp.calculate_qc_metrics.html) are in every case calculated. The computation of the additional QC metrics is **optional**. Please, leave the parameters empty to avoid running.
+
+|  |  |
+| ---- | --- |
+| `ccgenes` | __`str`__ (default: None) <br> Path to tsv-file used to run the function [scanpy.tl.score_genes_cell_cycle()](). It is expected, that the tsv-file has two columns with names `cc_phase` and `gene_name`. `cc_phase` can either be `s` or `g2m`.Varying the column names or `cc_phase` values will result in an error. Please refer to the [general guidelines]() for more information on the tsv file. <br> Instead of a path, the user can specify the parameter as "default" which then uses a [provided tsv file](https://github.com/DendrouLab/panpipes/blob/main/panpipes/resources/cell_cycle_genes.tsv).|
+| `custom_genes_file` | __`str`__ (default: None) <br> Path to csv-file containing a gene list with columns `group` and `feature`. Varying the column names will result in an error. Please refer to the [general guidelines]() for more information about the file. <br> The gene list is used to calculate the proportions of genes of a group in the cells/spots. More precise, the groups & genes are used for the `qc_vars` parameter of the function [scanpy.pp.calculate_qc_metrics](https://scanpy.readthedocs.io/en/stable/generated/scanpy.pp.calculate_qc_metrics.html) which accordingly calculates proportions. <br> Additionally the gene list is used to compute gene scores with [scanpy.tl.score_genes](https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.score_genes.html) <br> Instead of a path, the user can specify the parameter as "default" which then uses a [provided csv file](https://github.com/DendrouLab/panpipes/blob/main/panpipes/resources/qc_genelist_1.0.csv).|
+| `calc_proportions` | __`str`__ (default: None) <br>  Comma-separated string without spaces, e.g. _mito,hp,rp_. <br> For which groups of the csv-file specified in `custom_genes_file` to calculate percentages. |
+| `score_genes` | __`str`__ (default: None) <br> Comma-separated string without spaces, e.g. _mito,hp,rp_. <br> For which groups of the csv-file specified in `custom_genes_file`  to run [scanpy.tl.score_genes](https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.score_genes.html) |
+
+The following parameters specify the QC metrics to plot in violin and spatial embedding plots. Plots are generated for each slide specified in the submission file separately. 
+
+| `plotqc` |  |
+| --- | --- |
+| `grouping_var` | __`str`__ (default: None) <br> Comma-separated string without spaces, e.g. _sample_id,batch_ of categorical columns in `.obs`. One violin will be created for each group in the violin plot.|
+| `spatial_metrics` | __`str`__ (default: None) <br>  Comma-separated string without spaces, e.g. _total_counts,n_genes_by_counts_ of columns in `.obs` or `.var`. <br>Specifies which metrics to plot. If metric is present in both, `.obs` and `.var`, both will be plotted|

--- a/docs/yaml_docs/spatial_qc.md
+++ b/docs/yaml_docs/spatial_qc.md
@@ -1,11 +1,11 @@
 
-# Spatial QC yaml 
+# Spatial QC YAML 
 
-In this documentation, the parameters of the `qc_spatial` yaml file are explained. In general, the user can leave parameters empty to use defaults. <br> To understand the individual steps run by the pipeline, please refer to the [spatial QC workflow](). 
+In this documentation, the parameters of the `qc_spatial` yaml file are explained. In general, the user can leave parameters empty to use defaults. <br>  The individual steps run by the pipeline are described in the [spatial QC workflow](../workflows/ingest_spatial.md). 
 
 
 
-## 0. Compute resource options
+## 0. Compute Resource Options
 
 | `resources` |  |
 | --- | --- |
@@ -22,21 +22,21 @@ In this documentation, the parameters of the `qc_spatial` yaml file are explaine
 
 
 
-## 1. Loading options 
+## 1. Loading Options 
 
 |  |  |
 | ---- | --- |
 | `project` | __`str`__ (default: None) <br> Project name |
-| `submission_file` | __`str`__ (not optional) <br> Path to the submission file. The submission file specifies the input files. Please refer to the [general guidelines]() for details on the format of the file. |
+| `submission_file` | __`str`__ (not optional) <br> Path to the submission file. The submission file specifies the input files. Please refer to the [general guidelines](../usage/setup_for_spatial_workflows.md) for details on the format of the file. |
 
 
-## 2. QC options 
+## 2. QC Options 
 This part of the workflow allows to generate additional QC metrics that can be used for filtering/preprocessing. Basic QC metrics using [scanpy.pp.calculate_qc_metrics](https://scanpy.readthedocs.io/en/stable/generated/scanpy.pp.calculate_qc_metrics.html) are in every case calculated. The computation of the additional QC metrics is **optional**. Please, leave the parameters empty to avoid running.
 
 |  |  |
 | ---- | --- |
-| `ccgenes` | __`str`__ (default: None) <br> Path to tsv-file used to run the function [scanpy.tl.score_genes_cell_cycle()](). It is expected, that the tsv-file has two columns with names `cc_phase` and `gene_name`. `cc_phase` can either be `s` or `g2m`.Varying the column names or `cc_phase` values will result in an error. Please refer to the [general guidelines]() for more information on the tsv file. <br> Instead of a path, the user can specify the parameter as "default" which then uses a [provided tsv file](https://github.com/DendrouLab/panpipes/blob/main/panpipes/resources/cell_cycle_genes.tsv).|
-| `custom_genes_file` | __`str`__ (default: None) <br> Path to csv-file containing a gene list with columns `group` and `feature`. Varying the column names will result in an error. Please refer to the [general guidelines]() for more information about the file. <br> The gene list is used to calculate the proportions of genes of a group in the cells/spots. More precise, the groups & genes are used for the `qc_vars` parameter of the function [scanpy.pp.calculate_qc_metrics](https://scanpy.readthedocs.io/en/stable/generated/scanpy.pp.calculate_qc_metrics.html) which accordingly calculates proportions. <br> Additionally the gene list is used to compute gene scores with [scanpy.tl.score_genes](https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.score_genes.html) <br> Instead of a path, the user can specify the parameter as "default" which then uses a [provided csv file](https://github.com/DendrouLab/panpipes/blob/main/panpipes/resources/qc_genelist_1.0.csv).|
+| `ccgenes` | __`str`__ (default: None) <br> Path to tsv-file used to run the function [scanpy.tl.score_genes_cell_cycle](https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.score_genes_cell_cycle.html). It is expected, that the tsv-file has two columns with names `cc_phase` and `gene_name`. `cc_phase` can either be `s` or `g2m`.**Varying the column names or `cc_phase` values will result in an error.** Please refer to the [general guidelines](../usage/gene_list_format.md) for more information on the tsv file. <br> Instead of a path, the user can specify the parameter as "default" which then uses a [provided tsv file](https://github.com/DendrouLab/panpipes/blob/main/panpipes/resources/cell_cycle_genes.tsv).|
+| `custom_genes_file` | __`str`__ (default: None) <br> Path to csv-file containing a gene list with columns `group` and `feature`. **Varying the column names will result in an error.** Please refer to the [general guidelines](../usage/gene_list_format.md) for more information about the file. <br> The gene list is used to calculate the proportions of genes of a group in the cells/spots. More precise, the groups & genes are used for the `qc_vars` parameter of the function [scanpy.pp.calculate_qc_metrics](https://scanpy.readthedocs.io/en/stable/generated/scanpy.pp.calculate_qc_metrics.html) which accordingly calculates proportions. <br> Additionally the gene list is used to compute gene scores with [scanpy.tl.score_genes](https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.score_genes.html) <br> Instead of a path, the user can specify the parameter as "default" which then uses a [provided csv file](https://github.com/DendrouLab/panpipes/blob/main/panpipes/resources/qc_genelist_1.0.csv).|
 | `calc_proportions` | __`str`__ (default: None) <br>  Comma-separated string without spaces, e.g. _mito,hp,rp_. <br> For which groups of the csv-file specified in `custom_genes_file` to calculate percentages. |
 | `score_genes` | __`str`__ (default: None) <br> Comma-separated string without spaces, e.g. _mito,hp,rp_. <br> For which groups of the csv-file specified in `custom_genes_file`  to run [scanpy.tl.score_genes](https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.score_genes.html) |
 
@@ -44,5 +44,5 @@ The following parameters specify the QC metrics to plot in violin and spatial em
 
 | `plotqc` |  |
 | --- | --- |
-| `grouping_var` | __`str`__ (default: None) <br> Comma-separated string without spaces, e.g. _sample_id,batch_ of categorical columns in `.obs`. One violin will be created for each group in the violin plot.|
-| `spatial_metrics` | __`str`__ (default: None) <br>  Comma-separated string without spaces, e.g. _total_counts,n_genes_by_counts_ of columns in `.obs` or `.var`. <br>Specifies which metrics to plot. If metric is present in both, `.obs` and `.var`, both will be plotted|
+| `grouping_var` | __`str`__ (default: None) <br> Comma-separated string without spaces, e.g. _sample_id,batch_ of categorical columns in `.obs`. One violin will be created for each group in the violin plot. Not mandatory, can be left empty.|
+| `spatial_metrics` | __`str`__ (default: None) <br>  Comma-separated string without spaces, e.g. _total_counts,n_genes_by_counts_ of columns in `.obs` or `.var`. <br>Specifies which metrics to plot. If metric is present in both, `.obs` and `.var`, **both will be plotted.**|

--- a/panpipes/panpipes/pipeline_deconvolution_spatial.py
+++ b/panpipes/panpipes/pipeline_deconvolution_spatial.py
@@ -122,28 +122,27 @@ def run_tangram(input_spatial, outfile_spatial, sample_prefix, input_singlecell)
         --figdir %(figdir)s
         --output_dir %(output_dir)s
               """
-
     # feature selection paramaters
-    if PARAMS['Tangram_feature_selection_gene_list'] is not None:
-        cmd += " --gene_list %(Tangram_feature_selection_gene_list)s"
-    if PARAMS['Tangram_feature_selection_rank_genes_labels_key'] is not None:
-        cmd += " --labels_key_rank_genes %('Tangram_feature_selection_rank_genes_labels_key)s"
-    if PARAMS['Tangram_feature_selection_rank_genes_layer'] is not None:
-        cmd += " --layer_rank_genes %(Tangram_feature_selection_rank_genes_layer)s"
-    if PARAMS['Tangram_feature_selection_rank_genes_n_genes'] is not None:
-        cmd += " --n_genes_rank %('Tangram_feature_selection_rank_genes_n_genes)s"
-    if PARAMS['Tangram_feature_selection_test_method'] is not None:
-        cmd += " --method_rank_genes %(Tangram_feature_selection_test_method)s"
-    if PARAMS['Tangram_feature_selection_rank_genes_correction_method'] is not None:
-        cmd += " --corr_method_rank_genes %(Tangram_feature_selection_rank_genes_correction_method)s"    
+    if PARAMS['Tangram_feature_selection']['gene_list'] is not None:
+        cmd += f' --gene_list {PARAMS["Tangram_feature_selection"]["gene_list"]}'
+    if PARAMS['Tangram_feature_selection']['rank_genes']['labels_key'] is not None:
+        cmd += f' --labels_key_rank_genes {PARAMS["Tangram_feature_selection"]["rank_genes"]["labels_key"]}'
+    if PARAMS['Tangram_feature_selection']['rank_genes']['layer'] is not None:
+        cmd += f" --layer_rank_genes {PARAMS['Tangram_feature_selection']['rank_genes']['layer']}"
+    if PARAMS['Tangram_feature_selection']['rank_genes']['n_genes'] is not None:
+        cmd += f" --n_genes_rank {PARAMS['Tangram_feature_selection']['rank_genes']['n_genes']}"
+    if PARAMS['Tangram_feature_selection']['rank_genes']['test_method'] is not None:
+        cmd += f" --method_rank_genes {PARAMS['Tangram_feature_selection']['rank_genes']['test_method']}"
+    if PARAMS['Tangram_feature_selection']['rank_genes']['correction_method'] is not None:
+        cmd += f" --corr_method_rank_genes {PARAMS['Tangram_feature_selection']['rank_genes']['correction_method']}"    
     
     # model parameters 
-    if PARAMS['Tangram_model_labels_key'] is not None:
-        cmd += " --labels_key_model %('Tangram_model_labels_key)s"
-    if PARAMS['Tangram_model_num_epochs'] is not None:
-        cmd += " --num_epochs %('Tangram_model_num_epochs)s"
-    if PARAMS['Tangram_model_device'] is not None:
-        cmd += " --device %('Tangram_model_device)s"
+    if PARAMS['Tangram_model']['labels_key'] is not None:
+        cmd += f" --labels_key_model {PARAMS['Tangram_model']['labels_key']}"
+    if PARAMS['Tangram_model']['num_epochs'] is not None:
+        cmd += f" --num_epochs {PARAMS['Tangram_model']['num_epochs']}"
+    if PARAMS['Tangram_model']['device'] is not None:
+        cmd += f" --device {PARAMS['Tangram_model']['device']}"
 
     cmd += " > logs/%(log_file)s "
     job_kwargs["job_threads"] = PARAMS['resources_threads_low']

--- a/panpipes/panpipes/pipeline_deconvolution_spatial.py
+++ b/panpipes/panpipes/pipeline_deconvolution_spatial.py
@@ -32,8 +32,7 @@ def gen_filter_jobs():
         sample_prefix = os.path.basename(input_spatial)
         sample_prefix = sample_prefix.replace(".h5mu","")
         outfile_spatial = "cell2location.output/" + sample_prefix + "/Cell2Loc_spatial_output.h5mu"
-        yield input_spatial, outfile_spatial, sample_prefix, input_singlecell
-
+        yield input_spatial, outfile_spatial, sample_prefix, input_singlecell    
 
 
 @mkdir("logs")
@@ -54,52 +53,53 @@ def run_cell2location(input_spatial, outfile_spatial, sample_prefix, input_singl
         --figdir %(figdir)s
         --output_dir %(output_dir)s
               """
-    
     # feature selection paramaters
-    if PARAMS['Cell2Location_gene_list'] is not None:
-        cmd += " --gene_list %(Cell2Location_gene_list)s"
-    if PARAMS['Cell2Location_remove_mt'] is not None:
-        cmd += " --remove_mt %(Cell2Location_remove_mt)s"
-    if PARAMS['Cell2Location_cell_count_cutoff'] is not None:
-        cmd += " --cell_count_cutoff %(Cell2Location_cell_count_cutoff)s"
-    if PARAMS['Cell2Location_cell_percentage_cutoff2'] is not None:
-        cmd += " --cell_percentage_cutoff2 %(Cell2Location_cell_percentage_cutoff2)s"
-    if PARAMS['Cell2Location_nonz_mean_cutoff'] is not None:
-        cmd += " --nonz_mean_cutoff %(Cell2Location_nonz_mean_cutoff)s"
-    
+    if PARAMS['Cell2Location_feature_selection']['gene_list'] is not None:
+        cmd += f" --gene_list {PARAMS['Cell2Location_feature_selection']['gene_list']}"
+    if PARAMS['Cell2Location_feature_selection']['remove_mt'] is not None:
+        cmd += f" --remove_mt {PARAMS['Cell2Location_feature_selection']['remove_mt']}"
+    if PARAMS['Cell2Location_feature_selection']['cell_count_cutoff'] is not None:
+        cmd += f" --cell_count_cutoff {PARAMS['Cell2Location_feature_selection']['cell_count_cutoff']}"
+    if PARAMS['Cell2Location_feature_selection']['cell_percentage_cutoff2'] is not None:
+        cmd += f" --cell_percentage_cutoff2 {PARAMS['Cell2Location_feature_selection']['cell_percentage_cutoff2']}"
+    if PARAMS['Cell2Location_feature_selection']['nonz_mean_cutoff'] is not None:
+        cmd += f" --nonz_mean_cutoff {PARAMS['Cell2Location_feature_selection']['nonz_mean_cutoff']}"
     # parameters for the reference model
-    if PARAMS['Cell2Location_labels_key_reference'] is not None:
-        cmd += " --labels_key_reference %(Cell2Location_labels_key_reference)s"
-    if PARAMS['Cell2Location_batch_key_reference'] is not None:
-        cmd += " --batch_key_reference %(Cell2Location_batch_key_reference)s"
-    if PARAMS['Cell2Location_layer_reference'] is not None:
-        cmd += " --layer_reference %(Cell2Location_layer_reference)s"
-    if PARAMS['Cell2Location_categorical_covariate_keys_reference'] is not None:
-        cmd += " --categorical_covariate_keys_reference %(Cell2Location_categorical_covariate_keys_reference)s"
-    if PARAMS['Cell2Location_continuous_covariate_keys_reference'] is not None:
-        cmd += " --continuous_covariate_keys_reference %(Cell2Location_continuous_covariate_keys_reference)s"
-    if PARAMS['Cell2Location_max_epochs_reference'] is not None:
-        cmd += " --max_epochs_reference %(Cell2Location_max_epochs_reference)s"
-    
-        # parameters for the spatial model
-    if PARAMS['Cell2Location_batch_key_st'] is not None:
-        cmd += " --batch_key_st %(Cell2Location_batch_key_st)s"
-    if PARAMS['Cell2Location_layer_st'] is not None:
-        cmd += " --layer_st %(Cell2Location_layer_st)s"
-    if PARAMS['Cell2Location_categorical_covariate_keys_st'] is not None:
-        cmd += " --categorical_covariate_keys_st %(Cell2Location_categorical_covariate_keys_st)s"
-    if PARAMS['Cell2Location_continuous_covariate_keys_st'] is not None:
-        cmd += " --continuous_covariate_keys_st %(Cell2Location_continuous_covariate_keys_st)s"
-    if PARAMS['Cell2Location_max_epochs_st'] is not None:
-        cmd += " --max_epochs_st %(Cell2Location_max_epochs_st)s"
-    if PARAMS['Cell2Location_N_cells_per_location'] is not None:
-        cmd += " --N_cells_per_location %(Cell2Location_N_cells_per_location)s"
-    if PARAMS['Cell2Location_detection_alpha'] is not None:
-        cmd += " --detection_alpha %(Cell2Location_detection_alpha)s"
+    if PARAMS['Cell2Location_reference']['labels_key'] is not None:
+        cmd += f" --labels_key_reference {PARAMS['Cell2Location_reference']['labels_key']}"
+    if PARAMS['Cell2Location_reference']['batch_key'] is not None:
+        cmd += f" --batch_key_reference {PARAMS['Cell2Location_reference']['batch_key']}"
+    if PARAMS['Cell2Location_reference']['layer'] is not None:
+        cmd += f" --layer_reference {PARAMS['Cell2Location_reference']['layer']}"
+    if PARAMS['Cell2Location_reference']['categorical_covariate_keys'] is not None:
+        cmd += f" --categorical_covariate_keys_reference {PARAMS['Cell2Location_reference']['categorical_covariate_keys']}"
+    if PARAMS['Cell2Location_reference']['continuous_covariate_keys'] is not None:
+        cmd += f" --continuous_covariate_keys_reference {PARAMS['Cell2Location_reference']['continuous_covariate_keys']}"
+    if PARAMS['Cell2Location_reference']['max_epochs'] is not None:
+        cmd += f" --max_epochs_reference {PARAMS['Cell2Location_reference']['max_epochs']}"
+    if PARAMS['Cell2Location_reference']['use_gpu'] is not None:
+        cmd += f" --use_gpu_reference {PARAMS['Cell2Location_reference']['use_gpu']}" 
+    # parameters for the spatial model
+    if PARAMS['Cell2Location_spatial']['batch_key'] is not None:
+        cmd += f" --batch_key_st {PARAMS['Cell2Location_spatial']['batch_key']}"
+    if PARAMS['Cell2Location_spatial']['layer'] is not None:
+        cmd += f" --layer_st {PARAMS['Cell2Location_spatial']['layer']}"
+    if PARAMS['Cell2Location_spatial']['categorical_covariate_keys'] is not None:
+        cmd += f" --categorical_covariate_keys_st {PARAMS['Cell2Location_spatial']['categorical_covariate_keys']}"
+    if PARAMS['Cell2Location_spatial']['continuous_covariate_keys'] is not None:
+        cmd += f" --continuous_covariate_keys_st {PARAMS['Cell2Location_spatial']['continuous_covariate_keys']}"
+    if PARAMS['Cell2Location_spatial']['max_epochs'] is not None:
+        cmd += f" --max_epochs_st {PARAMS['Cell2Location_spatial']['max_epochs']}"
+    if PARAMS['Cell2Location_spatial']['N_cells_per_location'] is not None:
+        cmd += f" --N_cells_per_location {PARAMS['Cell2Location_spatial']['N_cells_per_location']}"
+    if PARAMS['Cell2Location_spatial']['detection_alpha'] is not None:
+        cmd += f" --detection_alpha {PARAMS['Cell2Location_spatial']['detection_alpha']}"
+    if PARAMS['Cell2Location_spatial']['use_gpu'] is not None:
+        cmd += f" --use_gpu_st {PARAMS['Cell2Location_spatial']['use_gpu']}"
     
     if PARAMS['Cell2Location_save_models'] is not None:
-        cmd += " --save_models %(Cell2Location_save_models)s"
-    
+        cmd += " --save_models %(Cell2Location_save_models)s"   
+
     cmd += " > logs/%(log_file)s "
     job_kwargs["job_threads"] = PARAMS['resources_threads_low']
     P.run(cmd, **job_kwargs)

--- a/panpipes/panpipes/pipeline_deconvolution_spatial.py
+++ b/panpipes/panpipes/pipeline_deconvolution_spatial.py
@@ -143,6 +143,9 @@ def run_tangram(input_spatial, outfile_spatial, sample_prefix, input_singlecell)
         cmd += f" --num_epochs {PARAMS['Tangram_model']['num_epochs']}"
     if PARAMS['Tangram_model']['device'] is not None:
         cmd += f" --device {PARAMS['Tangram_model']['device']}"
+    if PARAMS['Tangram_model']['kwargs'] is not None:
+        kwargs = PARAMS['Tangram_model']['kwargs'].__str__().replace("'", '"')
+        cmd += f" --kwargs '{kwargs}'"
 
     cmd += " > logs/%(log_file)s "
     job_kwargs["job_threads"] = PARAMS['resources_threads_low']

--- a/panpipes/panpipes/pipeline_deconvolution_spatial/pipeline.yml
+++ b/panpipes/panpipes/pipeline_deconvolution_spatial/pipeline.yml
@@ -1,12 +1,12 @@
-# ============================================================
-# Spatial Deconvolution workflow Panpipes (pipeline_deconvolution_spatial.py)
-# ============================================================
-# written by Sarah Ouologuem
+# ==========================================
+# Panpipes: Spatial Deconvolution Workflow 
+# ==========================================
+# Written by Sarah Ouologuem
 
 
-# ----------------------
+# ---------------------------
 # 0. Compute resource options
-# ------------------------
+# ---------------------------
 resources:
   # Number of threads used for parallel jobs
   threads_high: 1 # Must be enough memory to load all input files and create MuDatas
@@ -23,16 +23,17 @@ condaenv:  # Path to conda env, leave blank if running native or your cluster au
 
 # One or multiple slides can be deconvoluted with the same reference in one run. For that, one MuData object for each slide is expected. 
 
-input_spatial: data/spatial_data # Path to folder containing one or multiple MuDatas of spatial data. For all MuData files in that folder, deconvolution is run by the pipeline.
+input_spatial:  # Path to folder containing one or multiple MuDatas of spatial data. The pipeline is reading in all MuData files in that folder and assuming that they are MuDatas of spatial slides. 
+# For all MuData files in that folder, deconvolution is run by the pipeline.
 # In the MuData objects, the spatial data is expected to be saved in mudata.mod["spatial"]. For each spatial MuData, deconvolution is run with "input_singlecell" (see below) as a reference
 
-input_singlecell: data/single_cell_reference.h5mu # Path to the MuData file of the reference single-cell data, reference data expected to be saved in mudata.mod["rna"]
-
+input_singlecell:  # Path to the MuData file of the reference single-cell data, reference data expected to be saved in mudata.mod["rna"]
 
 
 # ----------------------
 ## 2. Cell2Location
 # ----------------------
+
 Cell2Location: 
   run: True # Whether to run Cell2Location 
   
@@ -91,6 +92,10 @@ Cell2Location:
 
 
 
+# -------------
+## 3. Tangram
+# -------------
+
 Tangram: 
   run: True # Whether to run Tangram 
 
@@ -108,8 +113,8 @@ Tangram:
       labels_key: cell_type # Which column in .obs of the reference to use for the 'groupby' parameter of sc.tl.rank_genes_groups()
       layer: Null # Default None, which layer to use of the reference for sc.tl.rank_genes_groups(). if Null (i.e. None), uses .X
       n_genes: 100 # Default 100, how many top genes to select of each 'groupby' group
-      test_method: wilcoxon # Default t-test_overestim_var, which test method to use. one of: ['logreg', 't-test', 'wilcoxon', 't-test_overestim_var']
-      correction_method: benjamini-hochberg # Default benjamini-hochberg, which p-value correction method to use. one of: ['benjamini-hochberg', 'bonferroni']. Used only for 't-test', 't-test_overestim_var', and 'wilcoxon'
+      test_method: wilcoxon # Default t-test_overestim_var, which test method to use. one of ['logreg', 't-test', 'wilcoxon', 't-test_overestim_var']
+      correction_method: benjamini-hochberg # Default benjamini-hochberg, which p-value correction method to use. one of ['benjamini-hochberg', 'bonferroni']. Used only for 't-test', 't-test_overestim_var', and 'wilcoxon'
 
   model: 
     labels_key: # Default None, cell type key in the reference .obs

--- a/panpipes/panpipes/pipeline_deconvolution_spatial/pipeline.yml
+++ b/panpipes/panpipes/pipeline_deconvolution_spatial/pipeline.yml
@@ -120,8 +120,9 @@ Tangram:
     labels_key: # Default None, cell type key in the reference .obs
     num_epochs: # Default 1000. Number of epochs for tangram.mapping_utils.map_cells_to_space()
     device: cpu # Default cpu. Device to use for deconvolution
-    kwargs: # Parameters for tangram.mapping_utils.map_cells_to_space()
-
+    kwargs: # Parameters for tangram.mapping_utils.map_cells_to_space(), feel free to add or remove parameters below 
+      learning_rate: 0.1
+      lambda_d: 0
 
 
 

--- a/panpipes/panpipes/pipeline_deconvolution_spatial/pipeline.yml
+++ b/panpipes/panpipes/pipeline_deconvolution_spatial/pipeline.yml
@@ -22,12 +22,12 @@ condaenv:  # Path to conda env, leave blank if running native or your cluster au
 # ----------------------
 
 # One or multiple slides can be deconvoluted with the same reference in one run. For that, one MuData object for each slide is expected. 
-
-input_spatial:  # Path to folder containing one or multiple MuDatas of spatial data. The pipeline is reading in all MuData files in that folder and assuming that they are MuDatas of spatial slides. 
+input: 
+  spatial:  # Path to folder containing one or multiple MuDatas of spatial data. The pipeline is reading in all MuData files in that folder and assuming that they are MuDatas of spatial slides. 
 # For all MuData files in that folder, deconvolution is run by the pipeline.
 # In the MuData objects, the spatial data is expected to be saved in mudata.mod["spatial"]. For each spatial MuData, deconvolution is run with "input_singlecell" (see below) as a reference
+  singlecell:  # Path to the MuData file of the reference single-cell data, reference data expected to be saved in mudata.mod["rna"]
 
-input_singlecell:  # Path to the MuData file of the reference single-cell data, reference data expected to be saved in mudata.mod["rna"]
 
 
 # ----------------------
@@ -40,52 +40,52 @@ Cell2Location:
   # -------------------------------
   # Feature selection paramaters
   # -------------------------------
-  
+  feature_selection:
   # Reduced feature set can either be given  a) via a csv file of genes or b) feature selection will be performed à la Cell2Location, i.e. via the function: cell2location.utils.filtering.filter_genes()
   # If no file is given in a), b) will be run, i.e. feature selection is not optional. 
   
-  #  a) Path to a csv file containing a reduced feature set
-  gene_list: # A header in the csv is expected in the first row
+    # a) Path to a csv file containing a reduced feature set
+    gene_list: # A header in the csv is expected in the first row
   
-  # b) Parameters for Cell2Location's feature selection, leave empty to use defaults
-  # Whether to remove mitochondrial genes before feature selection 
-  remove_mt: False # Default True
-  # All genes detected in less than cell_count_cutoff cells will be excluded.
-  cell_count_cutoff: # Default 15, parameter of function cell2location.utils.filtering.filter_genes()
-  # All genes detected in at least this percentage of cells will be included.
-  cell_percentage_cutoff2: # Default 0.05, parameter of function cell2location.utils.filtering.filter_genes()
-  # Genes detected in the number of cells between the above-mentioned cutoffs are selected only when their average expression in non-zero cells is above this cutoff
-  nonz_mean_cutoff:  # Default 1.12, parameter of function cell2location.utils.filtering.filter_genes()
-
+    # b) Parameters for Cell2Location's feature selection, leave empty to use defaults
+    # Whether to remove mitochondrial genes before feature selection 
+    remove_mt: False # Default True
+    # All genes detected in less than cell_count_cutoff cells will be excluded.
+    cell_count_cutoff: # Default 15, parameter of function cell2location.utils.filtering.filter_genes()
+    # All genes detected in at least this percentage of cells will be included.
+    cell_percentage_cutoff2: # Default 0.05, parameter of function cell2location.utils.filtering.filter_genes()
+    # Genes detected in the number of cells between the above-mentioned cutoffs are selected only when their average expression in non-zero cells is above this cutoff
+    nonz_mean_cutoff:  # Default 1.12, parameter of function cell2location.utils.filtering.filter_genes()
 
   # -------------------------------
   # Reference model paramaters
   # Leave empty to use defaults
   # -------------------------------
-  labels_key_reference: cell_type # Default None, key in adata.obs for label (cell type) information
-  batch_key_reference: # Default None, key in adata.obs for batch information
-  layer_reference: raw_counts # Default None (if None, X will be used), Layer of the raw (!) counts
-  categorical_covariate_keys_reference: key1,key2,key3 # Comma-separated without spaces; default None; keys in adata.obs that correspond to categorical data. These covariates can be added in addition to the batch covariate and are also treated as nuisance factors (i.e., the model tries to minimize their effects on the latent space)
-  continuous_covariate_keys_reference: key1,key2,key3 # Comma-separated without spaces; default None; keys in adata.obs that correspond to continuous data. These covariates can be added in addition to the batch covariate and are also treated as nuisance factors (i.e., the model tries to minimize their effects on the latent space)
-  
-  max_epochs_reference: 500 # Default np.min([round((20000 / n_cells) * 400), 400])
-
+  reference: 
+    labels_key: cell_type # Default None, key in adata.obs for label (cell type) information
+    batch_key: # Default None, key in adata.obs for batch information
+    layer: raw_counts # Default None (if None, X will be used), Layer of the raw (!) counts
+    categorical_covariate_keys: key1,key2,key3 # Comma-separated without spaces; default None; keys in adata.obs that correspond to categorical data. These covariates can be added in addition to the batch covariate and are also treated as nuisance factors (i.e., the model tries to minimize their effects on the latent space)
+    continuous_covariate_keys: key1,key2,key3 # Comma-separated without spaces; default None; keys in adata.obs that correspond to continuous data. These covariates can be added in addition to the batch covariate and are also treated as nuisance factors (i.e., the model tries to minimize their effects on the latent space)
+    max_epochs: 500 # Default np.min([round((20000 / n_cells) * 400), 400])
+    use_gpu: # Default True
 
   # -------------------------------
   # Spatial mapping model paramaters
   # Leave empty to use defaults
   # -------------------------------
-  batch_key_st: # Default None, key in adata.obs for batch information
-  layer_st: raw_counts # Default None (if None, X will be used), Layer of the raw (!) counts
-  categorical_covariate_keys_st: key1,key2,key3 # Comma-separated without spaces; default None; keys in adata.obs that correspond to categorical data. These covariates can be added in addition to the batch covariate and are also treated as nuisance factors (i.e., the model tries to minimize their effects on the latent space)
-  continuous_covariate_keys_st: key1,key2,key3 # Comma-separated without spaces; default None; keys in adata.obs that correspond to continuous data. These covariates can be added in addition to the batch covariate and are also treated as nuisance factors (i.e., the model tries to minimize their effects on the latent space)
+  spatial: 
+    batch_key: # Default None, key in adata.obs for batch information
+    layer: raw_counts # Default None (if None, X will be used), Layer of the raw (!) counts
+    categorical_covariate_keys: key1,key2,key3 # Comma-separated without spaces; default None; keys in adata.obs that correspond to categorical data. These covariates can be added in addition to the batch covariate and are also treated as nuisance factors (i.e., the model tries to minimize their effects on the latent space)
+    continuous_covariate_keys: key1,key2,key3 # Comma-separated without spaces; default None; keys in adata.obs that correspond to continuous data. These covariates can be added in addition to the batch covariate and are also treated as nuisance factors (i.e., the model tries to minimize their effects on the latent space)
   
-  # The following two parameters must be specified (cannot leave empty), otherwise an error will be thrown:
-  N_cells_per_location: 30 # Expected cell abundance per voxel
-  detection_alpha: 20 # Regularization of with-in experiment variation in RNA detection sensitivity
+    # The following two parameters must be specified (cannot leave empty), otherwise an error will be thrown:
+    N_cells_per_location: 30 # Expected cell abundance per voxel
+    detection_alpha: 20 # Regularization of with-in experiment variation in RNA detection sensitivity
   
-  max_epochs_st: 500 # Default np.min([round((20000 / n_cells) * 400), 400])
-
+    max_epochs: 500 # Default np.min([round((20000 / n_cells) * 400), 400])
+    use_gpu: # Default True 
 
  # -------------------------------
   save_models: False # Whether to save the reference and spatial mapping models

--- a/panpipes/panpipes/pipeline_deconvolution_spatial/pipeline.yml
+++ b/panpipes/panpipes/pipeline_deconvolution_spatial/pipeline.yml
@@ -91,6 +91,31 @@ Cell2Location:
 
 
 
+Tangram: 
+  run: True # Whether to run Tangram 
+
+  # -------------------------------
+  # Feature selection paramaters
+  # -------------------------------
+  # Reduced feature set can either be given  a) via a csv file of genes or b) sc.tl.rank_genes_groups() is run and the top n markers of each group are selected 
+  # If no file is given in a), b) will be run, i.e. feature selection is not optional.  
+  feature_selection: 
+    #  a) Path to a csv file containing a reduced feature set
+    gene_list: # A header in the csv is expected in the first row
+
+    # b) Parameters for sc.tl.rank_genes_groups() gene selection.
+    rank_genes: 
+      labels_key: cell_type # Which column in .obs of the reference to use for the 'groupby' parameter of sc.tl.rank_genes_groups()
+      layer: Null # Default None, which layer to use of the reference for sc.tl.rank_genes_groups(). if Null (i.e. None), uses .X
+      n_genes: 100 # Default 100, how many top genes to select of each 'groupby' group
+      test_method: wilcoxon # Default t-test_overestim_var, which test method to use. one of: ['logreg', 't-test', 'wilcoxon', 't-test_overestim_var']
+      correction_method: benjamini-hochberg # Default benjamini-hochberg, which p-value correction method to use. one of: ['benjamini-hochberg', 'bonferroni']. Used only for 't-test', 't-test_overestim_var', and 'wilcoxon'
+
+  model: 
+    labels_key: # Default None, cell type key in the reference .obs
+    num_epochs: # Default 1000. Number of epochs for tangram.mapping_utils.map_cells_to_space()
+    device: cpu # Default cpu. Device to use for deconvolution
+    kwargs: # Parameters for tangram.mapping_utils.map_cells_to_space()
 
 
 

--- a/panpipes/panpipes/pipeline_deconvolution_spatial/pipeline.yml
+++ b/panpipes/panpipes/pipeline_deconvolution_spatial/pipeline.yml
@@ -9,7 +9,7 @@
 # ---------------------------
 resources:
   # Number of threads used for parallel jobs
-  threads_high: 1 # Must be enough memory to load all input files and create MuDatas
+  threads_high: 1 # Number of threads used for high intensity computing tasks
   threads_medium: 1  # Must be enough memory to load your mudata and do computationally light tasks
   threads_low: 1 # Must be enough memory to load text files and do plotting, requires much less memory
 
@@ -25,7 +25,7 @@ condaenv:  # Path to conda env, leave blank if running native or your cluster au
 input: 
   spatial:  # Path to folder containing one or multiple MuDatas of spatial data. The pipeline is reading in all MuData files in that folder and assuming that they are MuDatas of spatial slides. 
 # For all MuData files in that folder, deconvolution is run by the pipeline.
-# In the MuData objects, the spatial data is expected to be saved in mudata.mod["spatial"]. For each spatial MuData, deconvolution is run with "input_singlecell" (see below) as a reference
+# In the MuData objects, the spatial data is expected to be saved in mudata.mod["spatial"]. For each spatial MuData, deconvolution is run with "singlecell" (see below) as a reference
   singlecell:  # Path to the MuData file of the reference single-cell data, reference data expected to be saved in mudata.mod["rna"]
 
 
@@ -68,7 +68,7 @@ Cell2Location:
     categorical_covariate_keys: key1,key2,key3 # Comma-separated without spaces; default None; keys in adata.obs that correspond to categorical data. These covariates can be added in addition to the batch covariate and are also treated as nuisance factors (i.e., the model tries to minimize their effects on the latent space)
     continuous_covariate_keys: key1,key2,key3 # Comma-separated without spaces; default None; keys in adata.obs that correspond to continuous data. These covariates can be added in addition to the batch covariate and are also treated as nuisance factors (i.e., the model tries to minimize their effects on the latent space)
     max_epochs: 500 # Default np.min([round((20000 / n_cells) * 400), 400])
-    use_gpu: # Default True
+    use_gpu: # Default True; whether to use GPU for training 
 
   # -------------------------------
   # Spatial mapping model paramaters
@@ -85,10 +85,10 @@ Cell2Location:
     detection_alpha: 20 # Regularization of with-in experiment variation in RNA detection sensitivity
   
     max_epochs: 500 # Default np.min([round((20000 / n_cells) * 400), 400])
-    use_gpu: # Default True 
+    use_gpu: # Default True; whether to use GPU for training
 
  # -------------------------------
-  save_models: False # Whether to save the reference and spatial mapping models
+  save_models: False # Default False; whether to save the reference and spatial mapping models
 
 
 

--- a/panpipes/panpipes/pipeline_deconvolution_spatial/pipeline.yml
+++ b/panpipes/panpipes/pipeline_deconvolution_spatial/pipeline.yml
@@ -1,6 +1,6 @@
-# ==========================================
-# Panpipes: Spatial Deconvolution Workflow 
-# ==========================================
+# =============================================================================================
+# Deconvolution, spatial transcriptomics workflow Panpipes (pipeline_deconvolution_spatial.py)
+# =============================================================================================
 # Written by Sarah Ouologuem
 
 

--- a/panpipes/panpipes/pipeline_preprocess_spatial/pipeline.yml
+++ b/panpipes/panpipes/pipeline_preprocess_spatial/pipeline.yml
@@ -9,7 +9,7 @@
 
 resources:
   # Number of threads used for parallel jobs
-  threads_high: 1 # Must be enough memory to load all input files and create MuDatas
+  threads_high: 1 # Number of threads used for high intensity computing tasks
   threads_medium: 1  # Must be enough memory to load your mudata and do computationally light tasks
   threads_low: 1 # Must be enough memory to load text files and do plotting, requires much less memory
 

--- a/panpipes/panpipes/pipeline_preprocess_spatial/pipeline.yml
+++ b/panpipes/panpipes/pipeline_preprocess_spatial/pipeline.yml
@@ -119,11 +119,11 @@ spatial:
   #    np.Inf: no clipping
 
   # Parameters for both cases norm_hvg_flavour = "seurat" and "squidpy":
-  n_top_genes: 2000 # Default is None; mandatory for norm_hvg_flavour = "seurat" and squidpy_hvg_flavor: "seurat_v3"
+  n_top_genes: 2000 # Leave blank to use default (2000); mandatory for norm_hvg_flavour = "seurat" and squidpy_hvg_flavor: "seurat_v3"
   filter_by_hvg: False # Leave blank to use default (False); if True, subset the data to highly-variable genes after finding them
   hvg_batch_key: # Leave blank to use default (None); if specified, highly-variable genes are selected within each batch separately and merged
 
-  n_pcs: 50 # Leave blank to use default (50); how many PCs to compute with sc.pp.PCA()
+  n_pcs: 50 # Leave blank to use default (50); how many PCs to compute with sc.pp.PCA() and plot in sc.pl.pca_variance_ratio()
 
 
 

--- a/panpipes/panpipes/pipeline_qc_spatial/pipeline.yml
+++ b/panpipes/panpipes/pipeline_qc_spatial/pipeline.yml
@@ -1,6 +1,6 @@
-# ============================================================
+# =============================================================================
 # Ingestion, spatial transcriptomics workflow Panpipes (pipeline_qc_spatial.py)
-# ============================================================
+# =============================================================================
 # Written by Fabiola Curion and Sarah Ouologuem
 
 
@@ -76,6 +76,6 @@ score_genes: MarkersNeutro # Comma-separated without spaces, which groups in the
 # All metrics and grouping variables should be inputted as a comma separated string without spaces, e.g. a,b,c
 
 plotqc:
-  grouping_var: sample_id # sample_id is the name of each spatial slide (specified in the submission file) and it will always be used to plot.
+  grouping_var: sample_id # sample_id is the name of each spatial slide (specified in the submission file)
   spatial_metrics: total_counts,n_genes_by_counts # If metric is present in both, .obs and .var, both will be plotted
 

--- a/panpipes/python_scripts/run_cell2location.py
+++ b/panpipes/python_scripts/run_cell2location.py
@@ -85,6 +85,9 @@ parser.add_argument("--continuous_covariate_keys_reference",
 parser.add_argument("--max_epochs_reference",
                     default=None,
                     help="")
+parser.add_argument("--use_gpu_reference",
+                    default=True,
+                    help="")
 
 # parameters for spatial model: 
 parser.add_argument("--labels_key_st",
@@ -111,6 +114,9 @@ parser.add_argument("--detection_alpha",
 parser.add_argument("--max_epochs_st",
                     default=None,
                     help="")  
+parser.add_argument("--use_gpu_st",
+                    default=True,
+                    help="")
 
 
 args, opt = parser.parse_known_args()
@@ -179,6 +185,14 @@ if args.max_epochs_st is None:
 else: 
     max_epochs_st= int(args.max_epochs_st)
 
+if (args.use_gpu_reference is True) or (args.use_gpu_reference == "True"): 
+    use_gpu_reference = True
+else:
+    use_gpu_reference = False
+if (args.use_gpu_st is True) or (args.use_gpu_st == "True"): 
+    use_gpu_st = True
+else:
+    use_gpu_st = False
 
 
 
@@ -234,7 +248,7 @@ c2l.models.RegressionModel.setup_anndata(adata=adata_sc,
                                          categorical_covariate_keys = categorical_covariate_keys_reference,
                                          continuous_covariate_keys =  continuous_covariate_keys_reference)
 model_ref = c2l.models.RegressionModel(adata_sc)
-model_ref.train(max_epochs=max_epochs_reference)
+model_ref.train(max_epochs=max_epochs_reference, use_gpu = use_gpu_reference)
 
 # plot elbo
 cell2loc_plot_history(model_ref, figdir + "/ELBO_reference_model.png")
@@ -271,7 +285,7 @@ c2l.models.Cell2location.setup_anndata(adata=adata_st,
 model_spatial = c2l.models.Cell2location(adata = adata_st, cell_state_df=inf_aver, 
                                         N_cells_per_location=float(args.N_cells_per_location),
                                         detection_alpha=float(args.detection_alpha))
-model_spatial.train(max_epochs=max_epochs_st)
+model_spatial.train(max_epochs=max_epochs_st, use_gpu = use_gpu_st)
 
 #plot elbo
 cell2loc_plot_history(model_spatial, figdir + "/ELBO_spatial_model.png")

--- a/panpipes/python_scripts/run_tangram.py
+++ b/panpipes/python_scripts/run_tangram.py
@@ -14,6 +14,7 @@ import os
 import argparse
 import sys
 import logging
+import json
 
 
 L = logging.getLogger()
@@ -72,7 +73,8 @@ parser.add_argument("--device",
                     default="cpu",
                     help="Device to use for deconvolution")
 parser.add_argument("--kwargs",
-                    default={},
+                    default='{}',
+                    type=str,
                     help="Parameters for tangram.mapping_utils.map_cells_to_space()")
 
 
@@ -81,6 +83,9 @@ args, opt = parser.parse_known_args()
 
 L.info("running with args:")
 L.debug(args)
+
+if isinstance(args.kwargs, str): 
+	args.kwargs = json.loads(args.kwargs)
 
 figdir = args.figdir
 if not os.path.exists(figdir):

--- a/panpipes/python_scripts/run_tangram.py
+++ b/panpipes/python_scripts/run_tangram.py
@@ -129,7 +129,10 @@ tg.project_cell_annotations(adata_results, adata_st, annotation=args.labels_key_
 annotation_list = list(pd.unique(adata_sc.obs[args.labels_key_model]))
 df = adata_st.obsm["tangram_ct_pred"][annotation_list]
 tg.construct_obs_plot(df, adata_st, perc=0.05)
-sc.pl.spatial(adata_st, color=annotation_list, cmap="viridis", show=False, frameon=False, ncols=3, save = "_tangram_ct_pred.png")
+if "spatial" in adata_st.uns: 
+	sc.pl.spatial(adata_st, color=annotation_list, cmap="viridis", show=False, frameon=False, ncols=3, save = "_tangram_ct_pred.png")
+else: 
+	sc.pl.spatial(adata_st, color=annotation_list, cmap="viridis", show=False, frameon=False, ncols=3, save = "_tangram_ct_pred.png",spot_size=0.5)
 
 
 mdata_singlecell_results = mu.MuData({"rna": adata_sc})

--- a/panpipes/python_scripts/run_tangram.py
+++ b/panpipes/python_scripts/run_tangram.py
@@ -1,0 +1,143 @@
+'''
+Run Tangram
+'''
+import warnings
+warnings.simplefilter(action='ignore', category=FutureWarning)
+
+import numpy as np
+import pandas as pd
+import scanpy as sc
+import tangram as tg
+import muon as mu
+
+import os
+import argparse
+import sys
+import logging
+
+
+L = logging.getLogger()
+L.setLevel(logging.INFO)
+log_handler = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter('%(asctime)s: %(levelname)s - %(message)s')
+log_handler.setFormatter(formatter)
+L.addHandler(log_handler)
+L.debug("testing logger works")
+
+
+
+sc.settings.verbosity = 3
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument("--input_spatial",
+                    help="path to mudata of spatial transcriptomics data")
+parser.add_argument("--input_singlecell",
+                    help="path to mudata of single-cell reference data")
+parser.add_argument("--figdir",
+                    default="./figures/Tangram",
+                    help="path to save the figures to")
+parser.add_argument("--output_dir",
+                    default="./tangram.output",
+                    help="path to save the output to")
+
+# parameters for feature selection: 
+parser.add_argument("--gene_list",
+                    default=None,
+                    help="path to a csv containing a list of genes to use for the deconvolution. csv-file needs to contain a header")
+parser.add_argument("--labels_key_rank_genes",
+                    default=None,
+                    help="which column in .obs of the reference to use for the 'groupby' parameter of sc.tl.rank_genes_groups()")
+parser.add_argument("--n_genes_rank",
+                    default=100,
+                    help="how many top genes to select of each 'groupby' group")
+parser.add_argument("--layer_rank_genes",
+                    default=None,
+                    help="which layer to use of the reference for sc.tl.rank_genes_groups(). if None, uses .X")
+parser.add_argument("--method_rank_genes",
+                    default=None,
+                    help="which test method to use. one of: ['logreg', 't-test', 'wilcoxon', 't-test_overestim_var']")
+parser.add_argument("--corr_method_rank_genes",
+                    default="benjamini-hochberg",
+                    help="which p-value correction method to use. one of: ['benjamini-hochberg', 'bonferroni']. Used only for 't-test', 't-test_overestim_var', and 'wilcoxon'")
+
+# model parameters
+parser.add_argument("--labels_key_model",
+                    default=None,
+                    help="cell type key in the reference .obs")
+parser.add_argument("--num_epochs",
+                    default=1000,
+                    help="Number of epochs for tangram.mapping_utils.map_cells_to_space()")
+parser.add_argument("--device",
+                    default=None,
+                    help="Device to use for deconvolution")
+parser.add_argument("--kwargs",
+                    default={},
+                    help="Parameters for tangram.mapping_utils.map_cells_to_space()")
+
+
+
+args, opt = parser.parse_known_args()
+
+L.info("running with args:")
+L.debug(args)
+
+figdir = args.figdir
+if not os.path.exists(figdir):
+    os.mkdir(figdir)
+sc.settings.figdir = figdir
+sc.set_figure_params(scanpy=True, fontsize=14, dpi=300, facecolor='white', figsize=(5,5))
+
+output_dir = args.output_dir
+if not os.path.exists(output_dir):
+    os.mkdir(output_dir)
+
+
+
+#1. read in the data
+#spatial: 
+mdata_spatial = mu.read(args.input_spatial)
+adata_st = mdata_spatial.mod['spatial']
+#single-cell: 
+mdata_singlecell = mu.read(args.input_singlecell)
+adata_sc = mdata_singlecell.mod['rna']
+
+
+#2. Perform gene selection:
+if args.gene_list is not None: # read in csv and create list 
+    markers = pd.read_csv(args.gene_list, header = 0)
+    markers = list(markers.iloc[:, 0])
+
+else: # perform feature selection using sc.tl.rank_genes_groups()
+    sc.tl.rank_genes_groups(adata_sc, groupby=args.labels_key_rank_genes, layer=args.layer_rank_genes, method=args.method_rank_genes,corr_method = args.corr_method_rank_genes)
+    sc.pl.rank_genes_groups(adata_sc, show = False, save = ".png")
+    markers_df = pd.DataFrame(adata_sc.uns["rank_genes_groups"]["names"]).iloc[0:int(args.n_genes_rank), :]
+    markers_df.to_csv(output_dir + "/rank_genes_groups.csv")
+    markers = list(np.unique(markers_df.melt().value.values))
+
+# "Preprocess" anndatas
+tg.pp_adatas(adata_sc=adata_st, adata_sp=adata_st, genes=markers)
+
+# 3. Run tangram
+adata_results = tg.mapping_utils.map_cells_to_space(
+        adata_sc=adata_sc, adata_sp=adata_st, num_epochs=int(args.num_epochs), device=args.device, **args.kwargs
+    )
+
+# 3. Extract and plot results 
+tg.project_cell_annotations(adata_results, adata_st, annotation=args.labels_key_model)
+
+annotation_list = list(pd.unique(adata_sc.obs[args.labels_key_model]))
+df = adata_st.obsm["tangram_ct_pred"][annotation_list]
+tg.construct_obs_plot(df, adata_st, perc=0.05)
+sc.pl.spatial(adata_st, color=annotation_list, cmap="viridis", show=False, frameon=False, ncols=3, save = "_tangram_ct_pred.png")
+
+
+mdata_singlecell.mod["rna"] = adata_sc
+mdata_singlecell.update()
+mdata_spatial.mod["spatial"] = adata_st
+mdata_spatial.update()
+
+mdata_singlecell.write(output_dir+"/Tangram_screference_output.h5mu")
+mdata_spatial.write(output_dir+"/Tangram_spatial_output.h5mu")
+
+L.info("Done")

--- a/panpipes/python_scripts/run_tangram.py
+++ b/panpipes/python_scripts/run_tangram.py
@@ -7,7 +7,7 @@ warnings.simplefilter(action='ignore', category=FutureWarning)
 import numpy as np
 import pandas as pd
 import scanpy as sc
-import tangram as tg
+import tangram as tg 
 import muon as mu
 
 import os
@@ -69,7 +69,7 @@ parser.add_argument("--num_epochs",
                     default=1000,
                     help="Number of epochs for tangram.mapping_utils.map_cells_to_space()")
 parser.add_argument("--device",
-                    default=None,
+                    default="cpu",
                     help="Device to use for deconvolution")
 parser.add_argument("--kwargs",
                     default={},
@@ -116,7 +116,7 @@ else: # perform feature selection using sc.tl.rank_genes_groups()
     markers = list(np.unique(markers_df.melt().value.values))
 
 # "Preprocess" anndatas
-tg.pp_adatas(adata_sc=adata_st, adata_sp=adata_st, genes=markers)
+tg.pp_adatas(adata_sc=adata_sc, adata_sp=adata_st, genes=markers)
 
 # 3. Run tangram
 adata_results = tg.mapping_utils.map_cells_to_space(
@@ -132,12 +132,10 @@ tg.construct_obs_plot(df, adata_st, perc=0.05)
 sc.pl.spatial(adata_st, color=annotation_list, cmap="viridis", show=False, frameon=False, ncols=3, save = "_tangram_ct_pred.png")
 
 
-mdata_singlecell.mod["rna"] = adata_sc
-mdata_singlecell.update()
-mdata_spatial.mod["spatial"] = adata_st
-mdata_spatial.update()
+mdata_singlecell_results = mu.MuData({"rna": adata_sc})
+mdata_spatial_results = mu.MuData({"spatial": adata_st})
 
-mdata_singlecell.write(output_dir+"/Tangram_screference_output.h5mu")
-mdata_spatial.write(output_dir+"/Tangram_spatial_output.h5mu")
+mdata_singlecell_results.write(output_dir+"/Tangram_screference_output.h5mu")
+mdata_spatial_results.write(output_dir+"/Tangram_spatial_output.h5mu")
 
 L.info("Done")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,8 @@ notebook = [
 ]
 spatial = [
     "squidpy",
-    "cell2location"
+    "cell2location",
+    "tangram-sc"
 ]
 pypi_upload = [
     "twine",


### PR DESCRIPTION
Hi!
I added the first drafts of the documentation files for `qc_spatial`, `preprocess_spatial`, and `deconvolution_spatial`. 

For the deconvolution, I merged the branch `sarah_deconvolution` into this branch, to be able to document the newest yaml file of the workflow. The new pipeline.yml of the deconvolution workflow has some structural changes for Cell2Location, an added parameter `use_gpu` for Cell2Location, and Tangram is added as a new method. 
The documentation of the  `deconvolution_spatial` yaml file, therefore, also includes Tangram.
(Note, that for Tangram I still need to update the [workflow](https://github.com/DendrouLab/panpipes/blob/sarah_yaml_doc/docs/workflows/deconvolute_spatial.md) documentation.)