### PR TITLE
Linked all ingestion pipeline.yml files in parameter doc

### DIFF
--- a/docs/yaml_docs/pipeline_ingestion_yml.md
+++ b/docs/yaml_docs/pipeline_ingestion_yml.md
@@ -15,9 +15,9 @@ This file is generated running `panpipes ingest config`.  <br> The individual st
 
 When running the ingestion workflow, panpipes provides a basic `pipeline.yml` file.
 To run the workflow on your own data, you need to specify the parameters described below in the `pipeline.yml` file to meet the requirements of your data.
-However, we do provide pre-filled versions of the `pipeline.yml` file for individual tutorials.
+However, we do provide pre-filled versions of the `pipeline.yml` file for individual [tutorials](https://panpipes-pipelines.readthedocs.io/en/latest/tutorials/index.html).
 You can download the different ingestion pipeline.yml files here:
-- Basic `pipeline.yml` file (not prefilled): [Download here](https://github.com/DendrouLab/panpipes/blob/main/panpipes/panpipes/pipeline_ingest/pipeline.yml)
+- Basic `pipeline.yml` file (not prefilled) that is generated when calling `panpipes ingest config: [Download here](https://github.com/DendrouLab/panpipes/blob/main/panpipes/panpipes/pipeline_ingest/pipeline.yml)
 - `pipeline.yml` file for [Ingesting data Tutorial](https://panpipes-tutorials.readthedocs.io/en/latest/ingesting_data/Ingesting_data_with_panpipes.html): [Download here](https://github.com/DendrouLab/panpipes-tutorials/blob/main/docs/ingesting_data/pipeline.yml)
 - `pipeline.yml` file for [Ingesting Mouse data Tutorial](https://panpipes-tutorials.readthedocs.io/en/latest/ingesting_mouse/Ingesting_mouse_data_with_panpipes.html): [Download here](https://github.com/DendrouLab/panpipes-tutorials/blob/main/docs/ingesting_mouse/pipeline.yml)
 - `pipeline.yml` file for [Ingesting multimodal (CITE-Seq + VDJ) data Tutorial](https://panpipes-tutorials.readthedocs.io/en/latest/ingesting_multimodal_data/ingesting_multimodal_data.html): [Download here](https://github.com/DendrouLab/panpipes-tutorials/blob/main/docs/ingesting_multimodal_data/pipeline.yml)

--- a/docs/yaml_docs/pipeline_ingestion_yml.md
+++ b/docs/yaml_docs/pipeline_ingestion_yml.md
@@ -13,6 +13,17 @@
 In this documentation, the parameters of the `ingest` configuration yaml file are explained. 
 This file is generated running `panpipes ingest config`.  <br> The individual steps run by the pipeline are described in the [spatial preprocess workflow](../workflows/qc.md). 
 
+When running the ingestion workflow, panpipes provides a basic `pipeline.yml` file.
+To run the workflow on your own data, you need to specify the parameters described below in the `pipeline.yml` file to meet the requirements of your data.
+However, we do provide pre-filled versions of the `pipeline.yml` file for individual tutorials.
+You can download the different ingestion pipeline.yml files here:
+- Basic `pipeline.yml` file (not prefilled): [Download here](https://github.com/DendrouLab/panpipes/blob/main/panpipes/panpipes/pipeline_ingest/pipeline.yml)
+- `pipeline.yml` file for [Ingesting data Tutorial](https://panpipes-tutorials.readthedocs.io/en/latest/ingesting_data/Ingesting_data_with_panpipes.html): [Download here](https://github.com/DendrouLab/panpipes-tutorials/blob/main/docs/ingesting_data/pipeline.yml)
+- `pipeline.yml` file for [Ingesting Mouse data Tutorial](https://panpipes-tutorials.readthedocs.io/en/latest/ingesting_mouse/Ingesting_mouse_data_with_panpipes.html): [Download here](https://github.com/DendrouLab/panpipes-tutorials/blob/main/docs/ingesting_mouse/pipeline.yml)
+- `pipeline.yml` file for [Ingesting multimodal (CITE-Seq + VDJ) data Tutorial](https://panpipes-tutorials.readthedocs.io/en/latest/ingesting_multimodal_data/ingesting_multimodal_data.html): [Download here](https://github.com/DendrouLab/panpipes-tutorials/blob/main/docs/ingesting_multimodal_data/pipeline.yml)
+- `pipeline.yml` file for [Ingesting multiome data from cellranger Tutorial](https://panpipes-tutorials.readthedocs.io/en/latest/ingesting_multiome/ingesting_mome.html): [Download here](https://github.com/DendrouLab/panpipes-tutorials/blob/main/docs/ingesting_multiome/pipeline.yml)
+
+
 ## Compute resources options
 
 * <p class="parameter">resources</p>

--- a/panpipes/panpipes/pipeline_ingest/pipeline.yml
+++ b/panpipes/panpipes/pipeline_ingest/pipeline.yml
@@ -2,7 +2,7 @@
 # Ingest workflow Panpipes (pipeline_ingest.py)
 # ============================================================
 # This file contains the parameters for the ingest workflow. 
-# For full descriptions of the parameters, see the documentation at TODO
+# For full descriptions of the parameters, see the documentation at https://panpipes-pipelines.readthedocs.io/en/latest/yaml_docs/pipeline_ingestion_yml.html
 
 
 #--------------------------
@@ -79,7 +79,7 @@ scr:
 # RNA modality Quality Control
 
 # Providing a gene list
-# see documentation at https://panpipes-pipelines.readthedocs.io/en/latest/usage/gene_list_format.html#
+# see documentation at https://panpipes-pipelines.readthedocs.io/en/latest/usage/gene_list_format.html
 custom_genes_file: resources/qc_genelist_1.0.csv
 
 # Defining actions on the genes


### PR DESCRIPTION
Closes issue #164.

Linking all the different versions of `pipeline.yml` for various ingestion tutorials will help users in navigating through the different versions of the file.

One aspect to discuss is whether the link to the actual file should direct users to the file in the GitHub Repo (allowing them to view it in the browser) or if it should provide a direct download link.