### PR TITLE
Fixed clr protein normalization margin options

### DIFF
--- a/docs/usage/normalization_methods.md
+++ b/docs/usage/normalization_methods.md
@@ -13,8 +13,8 @@ Additionally, the normalized data can be scaled using scanpy's [sc.pp.scale](htt
 ## PROT
 
 1. clr using [muon's prot processing](https://muon.readthedocs.io/en/latest/api/generated/muon.prot.pp.html), with the option to specify margin for normalization,
-   1. clr margin= 0, normalize within each feature's distribution, across all cells
-   2. clr margin= 1, normalize within each cells' counts distribution, across all features
+   1. clr margin= 0, normalize within each cells' counts distribution, across all features (row-wise, as you would do for RNA data)
+   2. clr margin= 1, normalize within each feature's distribution, across all cells (column-wise, recommended for proteomics data)
 
     *if you come from R, please note that the [margins are transposed](https://images.hindustantimes.com/rf/image_size_630x354/HT/p2/2017/09/21/Pictures/_78c6a162-9e94-11e7-9c3b-8e901839ece0.JPG) in the Python and anndata world*
 

--- a/docs/yaml_docs/pipeline_ingestion_yml.md
+++ b/docs/yaml_docs/pipeline_ingestion_yml.md
@@ -415,10 +415,10 @@ This can help to determine any inconsistencies in staining per channel and other
 
 ### Centered log ratio (CLR) normalization options
 
-<span class="parameter">clr_margin</span> `Integer`, Default: 0<br>
+<span class="parameter">clr_margin</span> `Integer`, Default: 1<br>
     Margin determines whether to normalize per cell (as you would do for RNA normalization), 
     or by feature (recommended, due to the variable nature of prot assays). 
-    CLR margin 0 is recommended for informative QC plots in this pipeline.
+    CLR margin 1 is recommended for informative QC plots in this pipeline.
   - 0 = normalise row-wise (per cell)
   - 1 = normalise column-wise (per feature, recommended)
 

--- a/docs/yaml_docs/pipeline_ingestion_yml.md
+++ b/docs/yaml_docs/pipeline_ingestion_yml.md
@@ -419,8 +419,8 @@ This can help to determine any inconsistencies in staining per channel and other
     Margin determines whether to normalize per cell (as you would do for RNA normalization), 
     or by feature (recommended, due to the variable nature of prot assays). 
     CLR margin 0 is recommended for informative QC plots in this pipeline.
-  - 0 = normalise rowwise (per feature, recommended)
-  - 1 = normalise colwise (per cell)
+  - 0 = normalise row-wise (per cell)
+  - 1 = normalise column-wise (per feature, recommended)
 
 ### Denoised and Scaled by Background (DSB) normalization options
  In order to run DSB you must have access to the complete raw counts, including the empty droplets from both rna and protein assays.

--- a/panpipes/panpipes/pipeline_ingest/pipeline.yml
+++ b/panpipes/panpipes/pipeline_ingest/pipeline.yml
@@ -176,8 +176,8 @@ normalisation_methods: clr
 # margin determines whether you normalise per cell (as you would for RNA),
 # or by feature (recommended, due to the variable nature of prot assays).
 # CLR margin 0 is recommended for informative qc plots in this pipeline
-# 0 = normalise rowwise (per feature)
-# 1 = normalise colwise (per cell)
+# 0 = normalise row-wise (per cell)
+# 1 = normalise column-wise (per feature, recommended)
 clr_margin: 0
 
 #--------------------------------------------------------------

--- a/panpipes/panpipes/pipeline_ingest/pipeline.yml
+++ b/panpipes/panpipes/pipeline_ingest/pipeline.yml
@@ -175,10 +175,10 @@ normalisation_methods: clr
 
 # margin determines whether you normalise per cell (as you would for RNA),
 # or by feature (recommended, due to the variable nature of prot assays).
-# CLR margin 0 is recommended for informative qc plots in this pipeline
+# CLR margin 1 is recommended for informative qc plots in this pipeline
 # 0 = normalise row-wise (per cell)
 # 1 = normalise column-wise (per feature, recommended)
-clr_margin: 0
+clr_margin: 1
 
 #--------------------------------------------------------------
 # Denoised and Scaled by Background (DSB) normalization options


### PR DESCRIPTION
This PR addresses the issue of the clr protein normalization options, which are described differently in several files. The version I settled on now:

> 0 = normalise row-wise (per cell)
1 = normalise column-wise (per feature, recommended)

But, I'm wondering why the default in the `pipeline.yml` is 0 when 1 is recommended. @bio-la, could you please double-check?