### PR TITLE
Changing qc sore_genes default  pipeline.yml

### DIFF
--- a/panpipes/panpipes/pipeline_ingest/pipeline.yml
+++ b/panpipes/panpipes/pipeline_ingest/pipeline.yml
@@ -86,7 +86,7 @@ custom_genes_file: resources/qc_genelist_1.0.csv
 
 # (for pipeline_ingest.py)
 calc_proportions: hb,mt,rp
-score_genes: MarkersNeutro
+score_genes: 
 
 # cell cycle action
 ccgenes: default


### PR DESCRIPTION
Changed the RNA QC score_genes default from MarkersNutro to blank in the ingest pipeline.yml