### PR TITLE
Updated installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,24 +25,24 @@ Available workflows:
 
 ## Installation and configuration
 
-See [installation instructions here](https://panpipes-pipelines.readthedocs.io/en/latest/install.html)
+For detailed installation instructions (including those for Apple Silicon machines), refer to the [installation instructions here](https://panpipes-pipelines.readthedocs.io/en/latest/install.html).
 
-We recommend installing panpipes in a conda environment, we provide a minimal conda config file in `pipeline_env.yaml`
+We recommend installing panpipes in a conda environment.
+For that, we provide a minimal conda config file in `pipeline_env.yaml`.
+First, clone this repository and navigate to the root directory of the repository:
+
+```
+git clone https://github.com/DendrouLab/panpipes.git
+cd panpipes
+```
+
+Then, create the conda environment and install the nightly version of panpipes using the following command:
 
 ```
 conda env create --file=pipeline_env.yaml 
 ```
 
-In this environment, you can install nightly version of panpipes, i.e. cloning this repo and installing it from main.
-
-```
-git clone https://github.com/DendrouLab/panpipes.git
-cd panpipes
-pip install -e .
-```
-
-
-Oxford BMRC Rescomp users find additional advice in [docs/installation_rescomp](https://github.com/DendrouLab/panpipes/blob/main/docs/installation_rescomp.md)
+Oxford BMRC Rescomp users find additional advice on the installation [here](https://github.com/DendrouLab/panpipes/blob/main/docs/installation_rescomp.md).
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ We recommend installing panpipes in a conda environment.
 For that, we provide a minimal conda config file in `pipeline_env.yaml`.
 First, clone this repository and navigate to the root directory of the repository:
 
-```
+```bash
 git clone https://github.com/DendrouLab/panpipes.git
 cd panpipes
 ```
 
 Then, create the conda environment and install the nightly version of panpipes using the following command:
 
-```
+```bash
 conda env create --file=pipeline_env.yaml 
 conda activate pipeline_env
 pip install -e .

--- a/README.md
+++ b/README.md
@@ -40,13 +40,15 @@ Then, create the conda environment and install the nightly version of panpipes u
 
 ```
 conda env create --file=pipeline_env.yaml 
+conda activate pipeline_env
+pip install -e .
 ```
 
 Oxford BMRC Rescomp users find additional advice on the installation [here](https://github.com/DendrouLab/panpipes/blob/main/docs/installation_rescomp.md).
 
 ## Releases
 
-Since `panpipes v0.4.0` ,the `ingest` workflow expects different headers for the RNA and Protein modalities from the previous releases.
+Since `panpipes v0.4.0`, the `ingest` workflow expects different headers for the RNA and Protein modalities from the previous releases.
 Check the example [submission file](https://github.com/DendrouLab/panpipes/blob/main/docs/usage/sample_file_qc_mm.md) and the [documentation](https://panpipes-pipelines.readthedocs.io/en/latest/usage/setup_for_qc_mm.html) for more detailed instructions.
 
 ## Citation

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,12 +1,12 @@
 
 # Installation of panpipes
 
->Note: Oxford BMRC Rescomp users find additional advice on the installation [here](https://github.com/DendrouLab/panpipes/blob/main/docs/installation_rescomp.md).
-
 We recommend running panpipes within a virtual environment to prevent conflicts.
 In the following, we provide instructions on how to do this using conda, mamba, or python venv.
 
->Note: For installation instructions on Apple machines with M chips, scroll down.
+> **Note**: For installation instructions on Apple machines with M chips, scroll down.
+
+> **Note**: Oxford BMRC Rescomp users find additional advice on the installation [here](https://github.com/DendrouLab/panpipes/blob/main/docs/installation_rescomp.md).
 
 ## Option 1: Installation in manually configured conda environment
 To run panpipes, we install it in a conda environment with R and python.
@@ -57,11 +57,12 @@ The extra `[spatial]` includes the `squidpy`, `cell2location`, and `tangram-sc` 
 
 ## Option 2: Install nightly panpipes version with preconfigured conda config file
 
-If you prefer to use the most recent development version, install panpipes the nightly version from the Github repository.
+If you prefer to use the most recent development version, install the nightly panpipes version from the Github repository.
 To make the installation easier, we provide a minimal conda config file in `pipeline_env.yaml`.
-First, clone the [panpipes repository](https://github.com/DendrouLab/panpipes) and navigate to the root directory of the repository:
 
 ### Clone the repository
+First, clone the [panpipes repository](https://github.com/DendrouLab/panpipes) and navigate to the root directory of the repository:
+
 ```bash
 git clone https://github.com/DendrouLab/panpipes.git
 cd panpipes
@@ -77,7 +78,8 @@ pip install -e .
 ```
 
 Panpipes requires the unix package `time`. 
-You can check if it installed with `dpkg-query -W time`. If time not already installed, you can 
+You can check if it installed with `dpkg-query -W time`.
+If `time` is not already installed, you can install it using:
 
 ```bash
 conda install time
@@ -91,8 +93,8 @@ apt-get install time
 
 
 ## Option 3: python venv environment
-As an alternative to conda, you can use a python virtual environment.
-Navigate to where you want to create your virtual environment and follow the steps below to create a pip virtual environment.
+As an alternative to a conda environment, you can also install panpipes in a python virtual environment.
+Navigate to where you want to create your virtual environment and follow the steps below to create a `pip` virtual environment.
 
 ```bash
 # Create a panpipes/venv folder
@@ -111,7 +113,7 @@ As explained above, you can install panpipes from `PyPi` with:
 pip install panpipes
 ```
 
-Alternatively, you can install a nightly version of panpipes by cloning the Github repository (see above for instructions).
+Alternatively, you can install a nightly version of panpipes by cloning the Github repository (see instructions above).
 
 ### R packages installation in python venv
 
@@ -119,7 +121,7 @@ If you are using a venv virtual environment, the pipeline will call a local R in
 (This executable requires that you specify a CRAN mirror in your `.Rprofile`).
 for example, add this line to your `.Rprofile` to automatically fetch the preferred mirror:
 
-*remember to customise with your preferred [R mirror](https://cran.r-project.org/mirrors.html).*
+> **Note:** Remember to customise with your preferred [R mirror](https://cran.r-project.org/mirrors.html).
 
 ```R
   options(repos = c(CRAN="https://cran.uni-muenster.de/"))
@@ -150,21 +152,21 @@ If you want to configure it on a HPC server, follow the next instructions.
 
 ## Installation on Apple Silicon M chips
 If you intend to install panpipes via conda on a macOS machine with M-Chip, you might face issues when installing or using certain workflows of panpipes.
-This is because panpipes relies on [scvi-tools], which currently only supports execution on Apple Silicon machines when installed using a native Python version (owing to a dependency on JAX).
+This is because panpipes relies on `scvi-tools`, which currently [only supports execution on Apple Silicon machines when installed using a native Python version](https://docs.scvi-tools.org/en/stable/installation.html#apple-silicon) (due to a dependency on JAX).
 
-Follow these steps to install pertpy on an Apple Silicon machine:
+Follow these steps to install panpipes on an Apple Silicon machine:
 
 1. Install [Homebrew](https://brew.sh/)
 
 2. Install Apple Silicon version of Mambaforge (If you already have Anaconda/Miniconda installed, make sure
-   having both mamba and conda won't cause conflicts). Additionally, we need clang which is included in llvm, so we install that as well.
+   having both mamba and conda won't cause conflicts). Additionally, we need clang which is included in llvm, so we install that as well:
 
 ```bash
 brew install --cask mambaforge
 brew install llvm
 ```
 
-3. Create a new environment using mamba (here with python 3.10) and activate it
+3. Create a new environment using mamba (here with python 3.10) and activate it:
 
 ```bash
 conda config --add channels conda-forge
@@ -176,14 +178,14 @@ mamba activate pipeline_env
 ```
 
 4. Add the osx-64 channel to the environment, then install Python and R
-Because not all R packages are available via the ARM64 channel, we need to specify the osx-64 channel to install all required R packages.
+Because not all R packages are available via the ARM64 channel, we need to specify the osx-64 channel to install all required R packages:
 
 ```bash
 conda config --env --set subdir osx-64
 mamba install python=3.10 r-base=4.3.0
 ```
 
-5. Install dependencies
+5. Install R dependencies and panpipes itself:
 
 ```bash
 conda install -c conda-forge r-tidyverse r-optparse r-ggforce r-ggraph r-xtable r-hdf5r r-clustree r-cowplot

--- a/docs/install.md
+++ b/docs/install.md
@@ -194,6 +194,8 @@ mamba install python=3.10 r-base=4.3.0
 conda install -c conda-forge r-tidyverse r-optparse r-ggforce r-ggraph r-xtable r-hdf5r r-clustree r-cowplot
 pip install panpipes
 ```
+
+
 You're all set to run `panpipes` on your local machine.
 If you want to configure it on a HPC server, follow the next instructions.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -3,38 +3,19 @@
 
 >Note: Oxford BMRC Rescomp users find additional advice on the installation [here](https://github.com/DendrouLab/panpipes/blob/main/docs/installation_rescomp.md).
 
-## Create virtual environment and install panpipes
-
 We recommend running panpipes within a virtual environment to prevent conflicts.
+In the following, we provide instructions on how to do this using conda, mamba, or python venv.
 
-### Option 1: Installation in conda environment (Recommended)
 >Note: For installation instructions on Apple machines with M chips, scroll down.
 
+## Option 1: Installation in manually configured conda environment
 To run panpipes, we install it in a conda environment with R and python.
 Panpipes has a lot of dependencies, so you may want to consider the faster [`mamba`](https://mamba.readthedocs.io/en/latest/index.html) instead of `conda` for installation.
-Panpipes can be installed via different methods, either from PyPi or from the Github repository.
-We recommend using Option 1.1 to install the nightly version of panpipes.
+Panpipes can be installed via different methods, either from `PyPi` or from the Github repository.
+Option 1 describes the installation via `PyPi` in a manually configured conda environment (no cloning of the repository necessary).
 
-#### Option 1.1: Nightly panpipes version with preconfigured conda config file (Recommended)
-We recommend installing a nightly version of panpipes.
-For that, we provide a minimal conda config file in `pipeline_env.yaml`.
-First, clone this repository and navigate to the root directory of the repository:
-
-```
-git clone https://github.com/DendrouLab/panpipes.git
-cd panpipes
-```
-
-Then, create the conda environment and install the nightly version of panpipes using the following command:
-
-```
-conda env create --file=pipeline_env.yaml 
-conda activate pipeline_env
-pip install -e .
-```
-
-#### Option 1.2: Manual conda environment creation
-As an alternative to the preconfigured conda environment, you can create a conda environment manually.
+### Create conda environment
+First, create a conda environment to run panpipes in:
 
 ```bash
 #This follows the suggestions made here: [https://www.biostars.org/p/498049/](https://www.biostars.org/p/498049/) 
@@ -57,13 +38,12 @@ Let's first install the R packages:
 conda install -c conda-forge r-tidyverse r-optparse r-ggforce r-ggraph r-xtable r-hdf5r r-clustree r-cowplot
 ```
 
-Finally, we install panpipes, which you can install either from PyPi or from the Github repository.
-
-##### Installing panpipes from PyPi
-
-You can install `panpipes` directly from `PyPi` with:
+### Install panpipes
+Finally, we install panpipes.
+You can install it either from `PyPi` (shown here) or a nightly version from the Github repository (shown in Option 2):
 
 ```bash
+# Install panpipes from PyPi
 pip install panpipes
 ```
 
@@ -72,15 +52,27 @@ If you intend to use panpipes for spatial analysis, instead install:
 ```bash
 pip install 'panpipes[spatial]'
 ```
-The extra `[spatial]` includes squidpy, cell2location, and tangram-sc packages.
+The extra `[spatial]` includes the `squidpy`, `cell2location`, and `tangram-sc` packages.
 
-##### Nightly version of panpipes
 
-If you prefer to use the most recent dev version, install panpipes from Github:
+## Option 2: Install nightly panpipes version with preconfigured conda config file
+
+If you prefer to use the most recent development version, install panpipes the nightly version from the Github repository.
+To make the installation easier, we provide a minimal conda config file in `pipeline_env.yaml`.
+First, clone the [panpipes repository](https://github.com/DendrouLab/panpipes) and navigate to the root directory of the repository:
+
+### Clone the repository
+```bash
+git clone https://github.com/DendrouLab/panpipes.git
+cd panpipes
+```
+
+### Create conda environment and install nightly panpipes version
+Then, create the conda environment and install the nightly version of panpipes using the following command:
 
 ```bash
-git clone https://github.com/DendrouLab/panpipes
-cd panpipes
+conda env create --file=pipeline_env.yaml 
+conda activate pipeline_env
 pip install -e .
 ```
 
@@ -97,7 +89,66 @@ or
 apt-get install time
 ```
 
-#### Installation on Apple Silicon M chips
+
+## Option 3: python venv environment
+As an alternative to conda, you can use a python virtual environment.
+Navigate to where you want to create your virtual environment and follow the steps below to create a pip virtual environment.
+
+```bash
+# Create a panpipes/venv folder
+python3 -m venv --prompt=panpipes python3-venv-panpipes/
+```
+
+Activate the environment:
+
+```bash
+source python3-venv-panpipes/bin/activate
+```
+
+As explained above, you can install panpipes from `PyPi` with:
+
+```bash
+pip install panpipes
+```
+
+Alternatively, you can install a nightly version of panpipes by cloning the Github repository (see above for instructions).
+
+### R packages installation in python venv
+
+If you are using a venv virtual environment, the pipeline will call a local R installation, so make sure R is installed and install the required packages with the command we provide below.
+(This executable requires that you specify a CRAN mirror in your `.Rprofile`).
+for example, add this line to your `.Rprofile` to automatically fetch the preferred mirror:
+
+*remember to customise with your preferred [R mirror](https://cran.r-project.org/mirrors.html).*
+
+```R
+  options(repos = c(CRAN="https://cran.uni-muenster.de/"))
+```
+
+Now, to automatically install the R dependecies, run:
+
+ ```bash
+panpipes install_r_dependencies
+ ```
+
+If you want more control over your installation use the [script on github](https://github.com/DendrouLab/panpipes/blob/main/panpipes/R_scripts/install_R_libs.R).
+Running with the option `--vanilla` or `--no-site-file` prevents R from reading your `.Renvironment` or `.Rprofile` in case you want to use different settings from you local R installation.
+You can expect the installation of R libraries to take quite some time, this is not something related to `panpipes` but how R manages their libraries and dependencies!
+
+### Check installation
+
+To check the installation was successful, run the following line:
+
+```bash
+panpipes --help
+```
+
+A list of available pipelines should appear!
+
+You're all set to run `panpipes` on your local machine.
+If you want to configure it on a HPC server, follow the next instructions.
+
+## Installation on Apple Silicon M chips
 If you intend to install panpipes via conda on a macOS machine with M-Chip, you might face issues when installing or using certain workflows of panpipes.
 This is because panpipes relies on [scvi-tools], which currently only supports execution on Apple Silicon machines when installed using a native Python version (owing to a dependency on JAX).
 
@@ -140,68 +191,11 @@ pip install panpipes
 ```
 
 
-### Option 2: python venv environment
-
-Navigate to where you want to create your virtual environment and follow the steps below to create a pip virtual environment.
-
-```bash
-python3 -m venv --prompt=panpipes python3-venv-panpipes/
-# This will create a panpipes/venv folder
-```
-
-Activate the environment
-
-```bash
-source python3-venv-panpipes/bin/activate
-```
-
-As explained in the conda installation, you can install `panpipes` with:
-
-```bash
-pip install panpipes
-```
-
-or install a nightly version of panpipes by cloning the Github repository.
-
-#### R packages installation in python venv
-
-If you are using a venv virtual environment, the pipeline will call a local R installation, so make sure R is installed and install the required packages with the command we provide below.
-(This executable requires that you specify a CRAN mirror in your `.Rprofile`).
-for example, add this line to your `.Rprofile` to automatically fetch the preferred mirror:
-
-*remember to customise with your preferred [R mirror](https://cran.r-project.org/mirrors.html).*
-
-```R
-  options(repos = c(CRAN="https://cran.uni-muenster.de/"))
-```
-
-Now, to automatically install the R dependecies, run:
-
- ```bash
-panpipes install_r_dependencies
- ```
-
-If you want more control over your installation use the [script on github](https://github.com/DendrouLab/panpipes/blob/main/panpipes/R_scripts/install_R_libs.R).
-Running with the option `--vanilla` or `--no-site-file` prevents R from reading your `.Renvironment` or `.Rprofile` in case you want to use different settings from you local R installation.
-You can expect the installation of R libraries to take quite some time, this is not something related to `panpipes` but how R manages their libraries and dependencies!
-
-#### Check installation
-
-To check the installation was successful run the following line
-
-```bash
-panpipes --help
-```
-
-A list of available pipelines should appear!
-
-You're all set to run `panpipes` on your local machine.
-If you want to configure it on a HPC server, follow the next instructions.
-
 ## Pipeline configuration for HPC clusters
 
-(For SGE or SLURM clusters)
-*Note: You only need this configuration step if you want to use an HPC to dispatch individual task as separate parallel jobs. You won't need this for a local installation of panpipes.*
+This section is for users who want to run panpipes on a High-Performance Computing (HPC) cluster with a job scheduler like SGE or SLURM.
+
+>Note: You only need this configuration step if you want to use an HPC to dispatch individual task as separate parallel jobs. You won't need this for a local installation of panpipes.
 
 Create a yml file for the cgat core pipeline software to read
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -76,6 +76,11 @@ conda env create --file=pipeline_env.yaml
 conda activate pipeline_env
 pip install -e .
 ```
+To install the spatial dependencies from the repo, use
+
+```bash
+pip install .[spatial]
+```
 
 Panpipes requires the unix package `time`. 
 You can check if it installed with `dpkg-query -W time`.
@@ -147,8 +152,6 @@ panpipes --help
 
 A list of available pipelines should appear!
 
-You're all set to run `panpipes` on your local machine.
-If you want to configure it on a HPC server, follow the next instructions.
 
 ## Installation on Apple Silicon M chips
 If you intend to install panpipes via conda on a macOS machine with M-Chip, you might face issues when installing or using certain workflows of panpipes.
@@ -191,7 +194,8 @@ mamba install python=3.10 r-base=4.3.0
 conda install -c conda-forge r-tidyverse r-optparse r-ggforce r-ggraph r-xtable r-hdf5r r-clustree r-cowplot
 pip install panpipes
 ```
-
+You're all set to run `panpipes` on your local machine.
+If you want to configure it on a HPC server, follow the next instructions.
 
 ## Pipeline configuration for HPC clusters
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,9 +4,9 @@
 We recommend running panpipes within a virtual environment to prevent conflicts.
 In the following, we provide instructions on how to do this using conda, mamba, or python venv.
 
-> **Note**: For installation instructions on Apple machines with M chips, scroll down.
-
-> **Note**: Oxford BMRC Rescomp users find additional advice on the installation [here](https://github.com/DendrouLab/panpipes/blob/main/docs/installation_rescomp.md).
+> **Note**: For installation instructions on **Apple machines with M chips**, scroll down.
+> If you are working on a **Windows** machine, please use Windows Subsystem for Linux (WSL) to run panpipes in order to have access to the latest r-base version.
+> **Oxford BMRC Rescomp** users find additional advice on the installation [here](https://github.com/DendrouLab/panpipes/blob/main/docs/installation_rescomp.md).
 
 ## Option 1: Installation in manually configured conda environment
 To run panpipes, we install it in a conda environment with R and python.

--- a/docs/install.md
+++ b/docs/install.md
@@ -29,6 +29,8 @@ Then, create the conda environment and install the nightly version of panpipes u
 
 ```
 conda env create --file=pipeline_env.yaml 
+conda activate pipeline_env
+pip install -e .
 ```
 
 #### Option 1.2: Manual conda environment creation
@@ -72,7 +74,7 @@ pip install 'panpipes[spatial]'
 ```
 The extra `[spatial]` includes squidpy, cell2location, and tangram-sc packages.
 
-##### Nightly versions of panpipes
+##### Nightly version of panpipes
 
 If you prefer to use the most recent dev version, install panpipes from Github:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -15,10 +15,9 @@ Panpipes can be installed via different methods, either from `PyPi` or from the 
 Option 1 describes the installation via `PyPi` in a manually configured conda environment (no cloning of the repository necessary).
 
 ### Create conda environment
-First, create a conda environment to run panpipes in:
+First, create a conda environment to run panpipes in. For that, we replicate the suggestions made [here](https://www.biostars.org/p/498049/):
 
-```bash
-#This follows the suggestions made here: [https://www.biostars.org/p/498049/](https://www.biostars.org/p/498049/) 
+```bash 
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 # you should remove the strict priority afterwards!

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,15 +1,38 @@
 
 # Installation of panpipes
 
-## Create virtual environment
+>Note: Oxford BMRC Rescomp users find additional advice on the installation [here](https://github.com/DendrouLab/panpipes/blob/main/docs/installation_rescomp.md).
+
+## Create virtual environment and install panpipes
 
 We recommend running panpipes within a virtual environment to prevent conflicts.
 
-### Option 1: create conda environment (Recommended)
+### Option 1: Installation in conda environment (Recommended)
 >Note: For installation instructions on Apple machines with M chips, scroll down.
 
-To Run panpipes, we install it in a conda environment with R and python.
+To run panpipes, we install it in a conda environment with R and python.
 Panpipes has a lot of dependencies, so you may want to consider the faster [`mamba`](https://mamba.readthedocs.io/en/latest/index.html) instead of `conda` for installation.
+Panpipes can be installed via different methods, either from PyPi or from the Github repository.
+We recommend using Option 1.1 to install the nightly version of panpipes.
+
+#### Option 1.1: Nightly panpipes version with preconfigured conda config file (Recommended)
+We recommend installing a nightly version of panpipes.
+For that, we provide a minimal conda config file in `pipeline_env.yaml`.
+First, clone this repository and navigate to the root directory of the repository:
+
+```
+git clone https://github.com/DendrouLab/panpipes.git
+cd panpipes
+```
+
+Then, create the conda environment and install the nightly version of panpipes using the following command:
+
+```
+conda env create --file=pipeline_env.yaml 
+```
+
+#### Option 1.2: Manual conda environment creation
+As an alternative to the preconfigured conda environment, you can create a conda environment manually.
 
 ```bash
 #This follows the suggestions made here: [https://www.biostars.org/p/498049/](https://www.biostars.org/p/498049/) 
@@ -20,21 +43,21 @@ conda search r-base
 conda create --name pipeline_env python=3.10 r-base=4.3.0
 ```
 
-now we activate the environment
+Next, we activate the environment:
 
 ```bash
 conda activate pipeline_env
 ```
 
-Let's first install the R packages
+Let's first install the R packages:
 
 ```bash
 conda install -c conda-forge r-tidyverse r-optparse r-ggforce r-ggraph r-xtable r-hdf5r r-clustree r-cowplot
 ```
 
-Then we can install panpipes:
+Finally, we install panpipes, which you can install either from PyPi or from the Github repository.
 
-#### 1. Installing panpipes from PyPi
+##### Installing panpipes from PyPi
 
 You can install `panpipes` directly from `PyPi` with:
 
@@ -49,9 +72,9 @@ pip install 'panpipes[spatial]'
 ```
 The extra `[spatial]` includes squidpy, cell2location, and tangram-sc packages.
 
-#### 2. Nightly versions of panpipes
+##### Nightly versions of panpipes
 
-If you prefer to use the most recent dev version, install from Github
+If you prefer to use the most recent dev version, install panpipes from Github:
 
 ```bash
 git clone https://github.com/DendrouLab/panpipes


### PR DESCRIPTION
- I updated the installation instructions in the README and the installation documentation in the docs.
- The recommended method now is to install panpipes  by cloning the repository, then creating a conda environment using the preconfigured `pipeline_env.yml` file, followed by installing the nightly version of panpipes.