### PR TITLE
Extended installation instructions for macOS

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -199,13 +199,26 @@ mamba install python=3.10 r-base=4.3.0
 5. Install R dependencies and panpipes itself:
 
 ```bash
-conda install -c conda-forge r-tidyverse r-optparse r-ggforce r-ggraph r-xtable r-hdf5r r-clustree r-cowplot
-pip install panpipes
+mamba install -c conda-forge r-tidyverse r-optparse r-ggforce r-ggraph r-xtable r-hdf5r r-clustree r-cowplot
+pip install panpipes # or install the nightly version by cloning the repository as described above
 ```
 
+6. Ensure the `time` package is installed
+If the `time` package is not already installed, you can install it using:
 
+```bash
+mamba install time
+```
 You're all set to run `panpipes` on your local machine.
-If you want to configure it on a HPC server, follow the next instructions.
+
+>Note: If you encounter an issue with the `jax` dependency when running panpipes, try reinstalling it from source:
+>```bash
+>pip uninstall jax jaxlib
+>mamba install -c conda-forge jaxlib
+>mamba install -c conda-forge jax
+>```
+
+If you want to configure it on an HPC server, follow the instructions in the following section.
 
 ## Pipeline configuration for HPC clusters
 


### PR DESCRIPTION
I have updated the installation instructions for macOS to address recent issues I encountered. Specifically, I have added a step to install the `time` package and provided guidance on resolving an issue I encountered when running JAX.