### PR TITLE
Integration workflow MultiVI and ATAC yaml fix

### DIFF
--- a/panpipes/panpipes/pipeline_integration/pipeline.yml
+++ b/panpipes/panpipes/pipeline_integration/pipeline.yml
@@ -113,7 +113,7 @@ prot:
 # ATAC modality
 atac:
   run: False
-  dimred: LSI
+  dimred: PCA
   tools:
   column: sample_id 
 

--- a/panpipes/panpipes/pipeline_integration/pipeline.yml
+++ b/panpipes/panpipes/pipeline_integration/pipeline.yml
@@ -113,7 +113,7 @@ prot:
 # ATAC modality
 atac:
   run: False
-  dimred: PCA
+  dimred: LSI
   tools:
   column: sample_id 
 
@@ -146,7 +146,8 @@ multimodal:
     - WNN
     - totalvi
     - multiVI
-  column_categorical: sample_id 
+  column_categorical: sample_id
+  column_continuous:
 
   # TotalVI arguments
   totalvi:


### PR DESCRIPTION
- Added column_continuous argument to yaml with no value so that ruffus correctly interprets it as None
- Changed default ATAC dimred to LSI
This fixes https://github.com/DendrouLab/panpipes/issues/294 and https://github.com/DendrouLab/panpipes/issues/293