### PR TITLE
Update run_filter.py

### DIFF
--- a/panpipes/python_scripts/run_filter.py
+++ b/panpipes/python_scripts/run_filter.py
@@ -180,7 +180,7 @@ write_obs(mdata, output_prefix=output_prefix, output_suffix="_filtered_cell_meta
 # write out the per sample_id cell numbers 
 cell_counts_dict={}
 for mm in mdata.mod.keys():
-    cell_counts_dict[mm] = mdata[mod].obs.sample_id.value_counts().to_frame('n_cells')
+    cell_counts_dict[mm] = mdata[mm].obs.sample_id.value_counts().to_frame('n_cells')
 
 cell_counts = pd.concat(cell_counts_dict).reset_index().rename(
     columns={"level_0": "modality", "level_1": "sample_id"})


### PR DESCRIPTION
There was an error in the for loop, the same variable wasnt being used across, leading to a mistake in the ncells counts per modality. as a stored `mod ` variable from the previous for loop used  durng filtering was being used instead. This leads to differences in cell numbers per sample_id per modality in the `preprocess workflow` output files `output_prefix_cell_counts.csv`  and `output_prefix_filtered_data.tsv`.  i wanted to thank @JHYSiu for finding this bug and flagging it. i have tested the change interactively in jupyter lab, and the ncell numbers per modality now match up with the preprocess object cel numbers.

Best,
Devika