### PR TITLE
LSI-enabled BBKNN

### DIFF
--- a/.github/workflows/integration03-ci.yml
+++ b/.github/workflows/integration03-ci.yml
@@ -62,7 +62,7 @@ jobs:
           curl -L -o teaseq.h5mu https://figshare.com/ndownloader/files/44796985
 
       # Note: we run the following to test that the commands works
-      # However, the following task will replacing the file anyway
+      # However, the following task will replace the file anyway
       - name: Preparing the configuration file
         shell: bash -el {0}
         run: |
@@ -72,7 +72,7 @@ jobs:
       - name: Edit the submission file
         run: |
           cd teaseq/integration
-          curl -o pipeline.yml https://github.com/DendrouLab/panpipes/raw/1849a8c65aa67702f423da2c3b2d1d9238adac6d/tests/integration_3/pipeline.yml ##https://raw.githubusercontent.com/DendrouLab/panpipes/main/tests/integration_3/pipeline.yml  
+          curl -o pipeline.yml https://github.com/DendrouLab/panpipes/raw/1849a8c65aa67702f423da2c3b2d1d9238adac6d/tests/integration_3/pipeline.yml 
       - name: Replace template contents in configuration file
         run: |
           cd teaseq/integration

--- a/.github/workflows/integration03-ci.yml
+++ b/.github/workflows/integration03-ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Edit the submission file
         run: |
           cd teaseq/integration
-          curl -o pipeline.yml https://raw.githubusercontent.com/DendrouLab/panpipes/main/tests/integration_3/pipeline.yml  
+          curl -o pipeline.yml https://github.com/DendrouLab/panpipes/raw/1849a8c65aa67702f423da2c3b2d1d9238adac6d/tests/integration_3/pipeline.yml ##https://raw.githubusercontent.com/DendrouLab/panpipes/main/tests/integration_3/pipeline.yml  
       - name: Replace template contents in configuration file
         run: |
           cd teaseq/integration

--- a/.github/workflows/integration03-ci.yml
+++ b/.github/workflows/integration03-ci.yml
@@ -1,0 +1,99 @@
+name: Run integration03
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  debug: 'true'
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"] # , "macos-latest", "windows-latest"
+        python-version: ["3.10"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: File tree
+        if: env.debug == 'true'
+        run: tree
+
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          auto-activate-base: true
+          auto-update-conda: true
+          channels: conda-forge
+          channel-priority: strict
+          activate-environment: pipeline_env
+          environment-file: pipeline_env.yaml
+# important: this patch is only to test if multivi integration works
+# issues are not related to panpipes https://discourse.scverse.org/t/error-when-training-model-on-m3-max-mps/1896/2
+# https://discourse.scverse.org/t/macbook-m1-m2-mps-acceleration-with-scvi/2075/4
+      - name: Install Panpipes
+        shell: bash -el {0}
+        run: |
+          pip install -e . 
+          conda list
+
+      - name: Conda info
+        if: env.debug == 'true'
+        shell: bash -el {0}
+        run: conda info
+
+      - name: Conda list
+        if: env.debug == 'true'
+        shell: pwsh
+        run: conda list
+
+      # Note: all three files are renamed during the download to trim the "subsample_" prefix
+      - name: Preparing the data
+        run: |
+          mkdir -p teaseq/integration && cd teaseq/integration
+          curl -L -o teaseq.h5mu https://figshare.com/ndownloader/files/44796985
+
+      # Note: we run the following to test that the commands works
+      # However, the following task will replacing the file anyway
+      - name: Preparing the configuration file
+        shell: bash -el {0}
+        run: |
+          cd teaseq/integration
+          panpipes integration config
+
+      - name: Edit the submission file
+        run: |
+          cd teaseq/integration
+          curl -o pipeline.yml https://raw.githubusercontent.com/DendrouLab/panpipes/main/tests/integration_3/pipeline.yml  
+      - name: Replace template contents in configuration file
+        run: |
+          cd teaseq/integration
+          sed -i 's+/Users/fabiola.curion/Documents/devel/miniconda3/envs/pipeline_env+pipeline_env+g' pipeline.yml
+
+      - name: File tree
+        if: env.debug == 'true'
+        run: tree teaseq
+
+      - name: Review pipeline tasks
+        shell: bash -el {0}
+        run: |
+          cd teaseq/integration
+          panpipes integration show full --local
+
+      - name: Run pipeline tasks
+        shell: bash -el {0}
+        run: |
+          cd teaseq/integration
+          panpipes integration make full --local
+
+      - name: File tree
+        if: env.debug == 'true'
+        run: tree teaseq

--- a/.github/workflows/integration03-ci.yml
+++ b/.github/workflows/integration03-ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Edit the submission file
         run: |
           cd teaseq/integration
-          curl -o pipeline.yml https://github.com/DendrouLab/panpipes/raw/1849a8c65aa67702f423da2c3b2d1d9238adac6d/tests/integration_3/pipeline.yml 
+          curl -o pipeline.yml https://raw.githubusercontent.com/DendrouLab/panpipes/1849a8c65aa67702f423da2c3b2d1d9238adac6d/tests/integration_3/pipeline.yml
       - name: Replace template contents in configuration file
         run: |
           cd teaseq/integration

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 Panpipes is a set of computational workflows designed to automate multimodal single-cell and spatial transcriptomic analyses by incorporating widely-used Python-based tools to perform quality control, preprocessing, integration, clustering, and reference mapping at scale.
 Panpipes allows reliable and customisable analysis and evaluation of individual and integrated modalities, thereby empowering decision-making before downstream investigations.
 
-**See our [documentation](https://panpipes-pipelines.readthedocs.io/en/latest/) and our [preprint](https://www.biorxiv.org/content/10.1101/2023.03.11.532085v2)**  
+**See our [documentation](https://panpipes-pipelines.readthedocs.io/en/latest/)**  
+
+**Panpipes is on [Genome Biology!](https://link.springer.com/article/10.1186/s13059-024-03322-7)**
 
 These workflows make use of [cgat-core](https://github.com/cgat-developers/cgat-core)
 
@@ -53,9 +55,9 @@ Check the example [submission file](https://github.com/DendrouLab/panpipes/blob/
 
 ## Citation
 
-[Panpipes: a pipeline for multiomic single-cell and spatial transcriptomic data analysis
-Fabiola Curion, Charlotte Rich-Griffin, Devika Agarwal, Sarah Ouologuem, Tom Thomas, Fabian J. Theis, Calliope A. Dendrou
-bioRxiv 2023.03.11.532085; doi: https://doi.org/10.1101/2023.03.11.532085](https://www.biorxiv.org/content/10.1101/2023.03.11.532085v2)
+[Curion, F., Rich-Griffin, C., Agarwal, D. et al. Panpipes: a pipeline for multiomic single-cell and spatial transcriptomic data analysis. Genome Biol 25, 181 (2024). 
+doi: https://doi.org/10.1186/s13059-024-03322-7](https://link.springer.com/article/10.1186/s13059-024-03322-7)
+
 
 ## Contributors
 

--- a/panpipes/panpipes/pipeline_integration.py
+++ b/panpipes/panpipes/pipeline_integration.py
@@ -545,7 +545,6 @@ def run_bbknn_atac(outfile):
         cmd += " --neighbors_within_batch %i" % PARAMS['atac']['bbknn']['neighbors_within_batch']
     if PARAMS['atac']['neighbors']['npcs'] is not None:
         cmd += " --neighbors_n_pcs %s" % PARAMS['atac']['neighbors']['npcs']
-    
     #cmd += " --dimred PCA"
     cmd += " > logs/3_atac_bbknn.log "
     if PARAMS['queues_long'] is not None:

--- a/panpipes/panpipes/pipeline_integration.py
+++ b/panpipes/panpipes/pipeline_integration.py
@@ -545,8 +545,8 @@ def run_bbknn_atac(outfile):
         cmd += " --neighbors_within_batch %i" % PARAMS['atac']['bbknn']['neighbors_within_batch']
     if PARAMS['atac']['neighbors']['npcs'] is not None:
         cmd += " --neighbors_n_pcs %s" % PARAMS['atac']['neighbors']['npcs']
-    #Forcing bbknn to run on PCA in case of atac
-    cmd += " --dimred PCA"
+    
+    #cmd += " --dimred PCA"
     cmd += " > logs/3_atac_bbknn.log "
     if PARAMS['queues_long'] is not None:
         job_kwargs["job_queue"] = PARAMS['queues_long']

--- a/tests/integration_3/pipeline.yml
+++ b/tests/integration_3/pipeline.yml
@@ -40,10 +40,10 @@ preprocessed_obj: teaseq.h5mu
 # unimodal: correct each modality independently
 rna:
   # True or false depending on whether you want to run batch correction
-  run: False 
+  run: True 
   # what method(s) to use to run batch correction, you can specify multiple 
   # choices: harmony,bbknn,scanorama,scvi (comma-seprated string, no spaces)
-  tools: harmony,scvi,bbknn
+  tools: harmony,scvi
   # this is the column you want to batch correct on. if you specify a comma separated list, 
   # they will be all used simultaneosly. 
   # Specifically all columns specified will be merged into one 'batch' columns.
@@ -78,12 +78,12 @@ rna:
         n_latent:
         gene_likelihood: zinb
     training_args:
-        max_epochs: 400
+        max_epochs: 40
         train_size: 0.9
         early_stopping: True
     training_plan: 
         lr: 0.001
-        n_epochs_kl_warmup: 400
+        n_epochs_kl_warmup: 40
         reduce_lr_on_plateau: True
         lr_scheduler_metric: 
         lr_patience: 8
@@ -152,9 +152,9 @@ prot:
 #--------------------------
 atac:
   # True or false depending on whether you want to run batch correction
-  run: True
+  run: False
   # which dimensionality reduction to expect, LSI or PCA
-  dimred: PCA 
+  dimred: LSI 
   # what method(s) to use to run batch correction, you can specify multiple 
   # (comma-seprated string, no spaces)
   # choices: harmony,bbknn,combat
@@ -205,7 +205,7 @@ multimodal:
   # choices: totalvi, mofa, MultiVI, WNN
   # list e.g. below
   tools: 
-    - MultiVI
+    - totalvi
 
   # this is the column you want to batch correct on. if you specify a comma separated list, 
   # they will be all used simultaneosly. if you want to test correction for one at a time, 
@@ -230,7 +230,7 @@ multimodal:
     model_args: 
       latent_distribution: "normal"
     training_args:
-      max_epochs: 100
+      max_epochs: 40
       train_size: 0.9
       early_stopping: True
     training_plan: None
@@ -240,6 +240,7 @@ multimodal:
     # you can add any other param from the tutorials and they will
     # be parsed alongside the others
     # leave arguments blank for default
+    seed: 1492
     lowmem: True
     # Set lowmem to True will subset the atac to the top 25k HVF. 
     # This is to deal with concatenation of atac,rna on large datasets which at the moment is suboptimally required by scvitools.
@@ -259,14 +260,14 @@ multimodal:
       fully_paired : False 
     training_args:
       #(default: 500)
-      max_epochs : 20 
+      max_epochs : 500 
       #float (default: 0.0001)
       lr : 1.0e-05
-      #leave blank for default str | int | bool | None (default: None)
+      #leave blanck for default str | int | bool | None (default: None)
       use_gpu :
       # float (default: 0.9)
       train_size : 0.9 
-      # leave blank for default, float | None (default: None)
+      # leave blanck for default, float | None (default: None)
       validation_size : 
       # int (default: 128)
       batch_size : 128
@@ -278,15 +279,15 @@ multimodal:
       early_stopping : True 
       #bool (default: True)
       save_best : True
-       #leave blank for default int | None (default: None)
+       #leave blanck for default int | None (default: None)
       check_val_every_n_epoch :
-      #leave blank for default int | None (default: None)
+      #leave blanck for default int | None (default: None)
       n_steps_kl_warmup : 
        # int | None (default: 50)
       n_epochs_kl_warmup : 50
       #bool (default: True)
-      adversarial_mixing : False 
-      #leave blank for default dict | None (default: None)
+      adversarial_mixing : True 
+       #leave blanck for default dict | None (default: None)
     training_plan :
   mofa:
     # this is a minimal set of parameters that will be expected
@@ -376,7 +377,6 @@ plotqc:
 # Choose the integration results you want to merge in the final object
 # For unimodal integration: to pick the uncorrected version use "no_correction"
 # then run
-
 # panpipes integration make merge_integration
 final_obj:
   rna:


### PR DESCRIPTION
Added an option to run BBKNN with LSI, removed forced PC calculation for ATAC
Uses `dimred` parameter from yaml to inform the choice of method (LSI/PCA). Default PCA.
Will calculate PCA if no dimred method found.

This fixes https://github.com/DendrouLab/panpipes/issues/296 and rapidly decreases RAM needed to run.