### PR TITLE
Add lowmem parameter to MOFA

### DIFF
--- a/panpipes/panpipes/pipeline_integration/pipeline.yml
+++ b/panpipes/panpipes/pipeline_integration/pipeline.yml
@@ -197,6 +197,7 @@ multimodal:
   mofa:
     modalities: rna,prot,atac
     filter_by_hvg: True
+    lowmem: True
     n_factors: 10
     n_iterations: 1000
     convergence_mode: fast


### PR DESCRIPTION
This solves https://github.com/DendrouLab/panpipes/issues/308

- Added `lowmem` option to `batch_correct_mofa.py`, which recalculates ATAC HVFs, keeping just top 25k
- Added `lowmem` to the integration YAML
- Fixed a bug where MOFA would error if `filter_by_hvg` in YAML is set to anything other than `True` (`filter_by_hvg` was erroneously passed to `mu.tl.mofa` kwargs)