### PR TITLE
Fix dsb background

### DIFF
--- a/panpipes/python_scripts/run_preprocess_prot.py
+++ b/panpipes/python_scripts/run_preprocess_prot.py
@@ -110,7 +110,7 @@ if 'dsb' in norm_methods:
       sys.exit("The MuData you specified does not contain rna modality. Cannot run dsb")
 
     # the RNA and PROT must intersect - they won't if experimental design included some cells without PROT data
-    L.info("Checking that only cells with PROT signal present are in the bacground object")
+    L.info("Checking that only cells with PROT signal present are in the background object")
     if all_mdata_bg['rna'].shape[0] != all_mdata_bg['prot'].shape[0]:
         mu.pp.intersect_obs(mdata_bg)
         all_mdata_bg.update()

--- a/panpipes/python_scripts/run_preprocess_prot.py
+++ b/panpipes/python_scripts/run_preprocess_prot.py
@@ -105,14 +105,9 @@ if 'dsb' in norm_methods:
         sys.exit("You must specify a background MuData to run dsb, containing both rna and prot")
 
     # RNA and PROT layer must be present in the object to run dsb
-    mods = list(all_mdata_bg.mod.keys())
-    if 'prot' not in mods:
-      L.error("The MuData you specified does not contain prot modality. Cannot run dsb")
-      sys.exit("The MuData you specified does not contain prot modality. Cannot run dsb")
-    if 'rna' not in mods:
+    if 'rna' not in list(all_mdata_bg.mod.keys()):
       L.error("The MuData you specified does not contain rna modality. Cannot run dsb")
       sys.exit("The MuData you specified does not contain rna modality. Cannot run dsb")
-    del mods
 
     # the RNA and PROT must intersect - they won't if experimental design included some cells without PROT data
     L.info("Checking that only cells with PROT signal present are in the bacground object")

--- a/panpipes/python_scripts/run_preprocess_prot.py
+++ b/panpipes/python_scripts/run_preprocess_prot.py
@@ -103,6 +103,22 @@ if 'dsb' in norm_methods:
     else:
         L.error("You must specify a background MuData to run dsb, containing both rna and prot")
         sys.exit("You must specify a background MuData to run dsb, containing both rna and prot")
+
+    # RNA and PROT layer must be present in the object to run dsb
+    mods = list(all_mdata_bg.mod.keys())
+    if 'prot' not in mods:
+      L.error("The MuData you specified does not contain prot modality. Cannot run dsb")
+      sys.exit("The MuData you specified does not contain prot modality. Cannot run dsb")
+    if 'rna' not in mods:
+      L.error("The MuData you specified does not contain rna modality. Cannot run dsb")
+      sys.exit("The MuData you specified does not contain rna modality. Cannot run dsb")
+    del mods
+
+    # the RNA and PROT must intersect - they won't if experimental design included some cells without PROT data
+    L.info("Checking that only cells with PROT signal present are in the bacground object")
+    if all_mdata_bg['rna'].shape[0] != all_mdata_bg['prot'].shape[0]:
+        mu.pp.intersect_obs(mdata_bg)
+        all_mdata_bg.update()
     
     # checking that the same proteins are in foreground and background (since foreground might have been filtered)
     L.info("Checking that the same proteins are in foreground and background")


### PR DESCRIPTION
- Added check to ensure prot and rna is present in mods before dsb runs, exit if not
- Added check to make sure only cells with prot information are retained in the background object (this caused an error for experimental designs where only a subset of cells has protein signal, not all)

Other intersection options (background object obs/unfiltered object obs,  background object obs/filtered object obs) which were suggested are not good because they would remove empty droplets needed for dsb.

This fixes #1 