### PR TITLE
Update pyproject.toml to fix the scirpy version to 0.12.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "scib",
     "scib-metrics",
     "scikit-misc",
-    "scirpy",
+    "scirpy==0.12.2",
     "scrublet",
     "scvi-tools",
     "sqlalchemy",


### PR DESCRIPTION
fixing the version of scripy==0.12.2 , as after that scirpy moved to awkward arrays and panpipes ingest hasnt been updated yet to work with the new data strucutre implement since the version v0.13.0. Without the fix, the latest version is installed b default which errors when ingesting repeortoire data with `panpipes_ingest`