### PR TITLE
Update run_scanpyQC_rna.py

### DIFF
--- a/panpipes/python_scripts/run_scanpyQC_rna.py
+++ b/panpipes/python_scripts/run_scanpyQC_rna.py
@@ -57,7 +57,7 @@ parser.add_argument("--calc_proportions",
                     default="mitochondrial,ribosomal",
                     help="which list of genes to use to calc proportion of mapped reads over total,per cell?")
 parser.add_argument("--score_genes",
-                    default="MarkersNeutro",
+                    default=None,
                     help="which list of genes to use to scanpy.tl.score_genes per cell?")
 
 args, opt = parser.parse_known_args()


### PR DESCRIPTION
Changed the default QC from MarkersNeutro to None, so if score_genes in ingest yaml is blank, it will not score genes. It also avoids errors is custom gene QC list is not the default one.

This fixes #316 .