### PR TITLE
Add Run option params LISI and SCIB metrics for pipeline_integration.py

### DIFF
--- a/panpipes/panpipes/pipeline_integration.py
+++ b/panpipes/panpipes/pipeline_integration.py
@@ -817,6 +817,7 @@ def plot_umaps(infile, outfile):
 
 #this can follow now any mtd generation, but it will collate only RNA jobs for lisi
 @follows(collate_integration_outputs)
+@active_if(PARAMS['lisi_run'])
 @transform(collate_integration_outputs, 
            formatter(),  'logs/7_lisi.log')
 def run_lisi(infile, outfile):
@@ -834,6 +835,7 @@ def run_lisi(infile, outfile):
 
 
 @follows(collate_integration_outputs)
+@active_if(PARAMS['scib_run'])
 @transform(collate_integration_outputs, formatter(),  'logs/scib.log')
 def run_scib_metrics(infile, outfile):
     cell_mtd_file = sprefix + "_cell_mtd.csv"

--- a/panpipes/panpipes/pipeline_integration/pipeline.yml
+++ b/panpipes/panpipes/pipeline_integration/pipeline.yml
@@ -244,6 +244,11 @@ plotqc:
   atac:
   multimodal: rna:total_counts
 
+#-------------
+# LISI metrics
+#-------------
+lisi:
+  run: True
 
 #-------------
 # scib metrics

--- a/panpipes/panpipes/pipeline_integration/pipeline.yml
+++ b/panpipes/panpipes/pipeline_integration/pipeline.yml
@@ -250,6 +250,7 @@ plotqc:
 #-------------
 #Obs columns containing the cell type labels
 scib:
+  run: True
   rna:
   prot:
   atac:


### PR DESCRIPTION
As mentioned in [issues#320](https://github.com/DendrouLab/panpipes/issues/320), i have added a `run` parameter for LISI and scib metrics. As sciB might fail on smaller datasets, but LISI sometimes takes hours on very bi datasets too and not everyone wants to run it. On default both are set as `True` but users can change to `False` if they want.