### PR TITLE
Refactor: Use .toarray() for sparse matrix conversion

### DIFF
--- a/panpipes/funcs/scmethods.py
+++ b/panpipes/funcs/scmethods.py
@@ -368,7 +368,7 @@ def _calc_top_n_genes(adata, n_top=50):
     if issparse(norm_dict['X']):
             mean_percent = norm_dict['X'].mean(axis=0).A1
             top_idx = np.argsort(mean_percent)[::-1][:n_top]
-            counts_top_genes = norm_dict['X'][:, top_idx].A
+            counts_top_genes = norm_dict['X'][:, top_idx].toarray()
     else:
         mean_percent = norm_dict['X'].mean(axis=0)
         top_idx = np.argsort(mean_percent)[::-1][:n_top]
@@ -412,7 +412,7 @@ def get_mean_background_fraction(adata, top_background, group_by=None):
     gene_idx = [idx for idx, gene in  enumerate(adata.var_names ) if gene in top_background]
     if issparse(norm_dict['X']):
         mean_percent = norm_dict['X'].mean(axis=0).A1
-        counts_top_genes = norm_dict['X'][:, gene_idx].A
+        counts_top_genes = norm_dict['X'][:, gene_idx].toarray()
     else:
         mean_percent = norm_dict['X'].mean(axis=0)
         counts_top_genes = norm_dict['X'][:, gene_idx]


### PR DESCRIPTION
Fixes #331

This PR replaces the use of the `.A` attribute with the `.toarray()` method when converting a SciPy sparse matrix to a dense array. While running the ingest wokrflow, an `AttributeError: 'csr_matrix' object has no attribute 'A'` is raised in the assess_background step. 

`python=3.10.16` `numpy=1.26.4` `scipy=1.15.2`

### Traceback
```
Traceback (most recent call last): 
File "/gpfs3/well/cartography/users/eef835/devel/panpipes/panpipes/python_scripts/assess_background.py", line 140, in <module> 
top_genes = pnp.scmethods.get_top_expressed_features(mdata_bg['rna'], n_top=30, group_by=args.channel_col) 
...
File "/gpfs3/well/cartography/users/eef835/devel/panpipes/panpipes/funcs/scmethods.py", line 371, in _calc_top_n_genes 
counts_top_genes = norm_dict['X'][:, top_idx].A 
AttributeError: 'csr_matrix' object has no attribute 'A'
```

### Fix

In `panpipes/funcs/scmethods.py`:

```diff
- counts_top_genes = norm_dict['X'][:, top_idx].A
+ counts_top_genes = norm_dict['X'][:, top_idx].toarray()

- counts_top_genes = norm_dict['X'][:, gene_idx].A
+ counts_top_genes = norm_dict['X'][:, gene_idx].toarray()
```


### Validation

With this change, the pipeline now runs successfully through the assess_background step. The fix was also verified using a minimal test script.

```
import numpy as np
from scipy.sparse import csr_matrix

sparse_mat = csr_matrix((np.array([1, 2, 3]), np.array([0, 2, 1]), np.array([0, 2, 3])), shape=(2, 3))

try:
    dense_array = sparse_mat.A
except AttributeError as e:
    print(f"Error: {e}")

dense_array = sparse_mat.toarray()
print(f"\nSuccess with .toarray():\n{dense_array}")
```


