### PR TITLE
Adds support for per-sample expected doublet rates in Scrublet

### DIFF
--- a/panpipes/panpipes/pipeline_ingest.py
+++ b/panpipes/panpipes/pipeline_ingest.py
@@ -358,6 +358,11 @@ def run_scrublet(infile, outfile, sample_id):
         --inputpath %(infile)s
         --outdir %(outdir)s
         """
+    if PARAMS['scr_per_sample']:
+        if PARAMS['scr_expected_doublet_rate_csv'] is None:
+            raise ValueError("scr.per_sample is True but scr.expected_doublet_rate_csv is not specified in pipeline.yml")
+        cmd += " --expected_doublet_rate_csv %(scr_expected_doublet_rate_csv)s"
+    # always pass the default expected doublet rate, the python script will prioritize the csv if it exists
     if PARAMS['scr_expected_doublet_rate'] is not None:
         cmd += " --expected_doublet_rate %(scr_expected_doublet_rate)s"
     if PARAMS['scr_sim_doublet_ratio'] is not None:

--- a/panpipes/panpipes/pipeline_ingest/pipeline.yml
+++ b/panpipes/panpipes/pipeline_ingest/pipeline.yml
@@ -65,10 +65,12 @@ plot_10X_metrics: True
 # Doublet detection on RNA modality
 scr:
   run: True
-  # option to run scrublet per sample expected doublet rate, expects a csv with sample_id and expected_doublet_rate columns
+  # If per_sample is False or the sample_id is missing from the CSV,
+  # use this default expected doublet rate.
   per_sample: False
   expected_doublet_rate_csv:
-  # if per_sample is False, this value is used for all samples
+  # If per_sample is False or the sample_id is missing from the CSV,
+  # use this default expected doublet rate.
   expected_doublet_rate: 0.06
   sim_doublet_ratio: 2
   n_neighbours: 20

--- a/panpipes/panpipes/pipeline_ingest/pipeline.yml
+++ b/panpipes/panpipes/pipeline_ingest/pipeline.yml
@@ -65,6 +65,10 @@ plot_10X_metrics: True
 # Doublet detection on RNA modality
 scr:
   run: True
+  # option to run scrublet per sample expected doublet rate, expects a csv with sample_id and expected_doublet_rate columns
+  per_sample: False
+  expected_doublet_rate_csv:
+  # if per_sample is False, this value is used for all samples
   expected_doublet_rate: 0.06
   sim_doublet_ratio: 2
   n_neighbours: 20

--- a/panpipes/resources/sample_expected_doublet_rates.csv
+++ b/panpipes/resources/sample_expected_doublet_rates.csv
@@ -1,0 +1,3 @@
+sample_id,expected_doublet_rate
+Sample1,0.10
+Sample2,0.7


### PR DESCRIPTION
### Overview
- Introduces the feature to specify expected doublet rates on a per-sample basis for doublet detection using scrublet for heterogeneous datasets.
- Enables configuration through a CSV file mapping sample identifiers to their expected doublet rates.
- Maintains fallback to a global default rate if per-sample data is unavailable or missing for a sample.

### Motivation
This update addresses the limitations of a single expected doublet rate by allowing tailored configurations, which can enhance doublet predictions when sample-specific rates are known or required.

### Details
- Updates configuration options to allow toggling per-sample rate usage and specifying the CSV file path.
- Modifies pipeline logic to read sample-specific rates from the CSV file and revert to the default as necessary.
- Adds a resource CSV example for user reference.